### PR TITLE
feat: iCloud sync for connection configs and credentials

### DIFF
--- a/MFuse/MFuse.entitlements
+++ b/MFuse/MFuse.entitlements
@@ -12,6 +12,18 @@
 	<array>
 		<string>group.com.lollipopkit.mfuse.shared</string>
 	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.lollipopkit.mfuse</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.com.lollipopkit.mfuse</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.lollipopkit.mfuse.shared</string>

--- a/MFuse/MFuseApp.swift
+++ b/MFuse/MFuseApp.swift
@@ -70,10 +70,10 @@ struct MFuseApp: App {
             registry: registry
         )
         manager.onLocalConnectionsDidChange = { _ in
-            guard SharedAppSettings.iCloudSyncEnabled else {
-                return
-            }
             Task { @MainActor in
+                guard SharedAppSettings.iCloudSyncEnabled else {
+                    return
+                }
                 do {
                     let result = try await iCloudSyncService.synchronize()
                     if result.didUpdateLocalSnapshot {

--- a/MFuse/MFuseApp.swift
+++ b/MFuse/MFuseApp.swift
@@ -14,6 +14,7 @@ struct MFuseApp: App {
     private static let cleanupFileProviderStateArgument = "--cleanup-file-provider-state"
     static let mainWindowID = "main"
 
+    @Environment(\.scenePhase) private var scenePhase
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var connectionManager: ConnectionManager
     @StateObject private var appSettings: AppSettingsStore
@@ -22,14 +23,18 @@ struct MFuseApp: App {
     private let mountProvider: FileProviderMountProvider
     private let storage: SharedStorage
     private let credentialProvider: MirroredCredentialProvider
+    private let iCloudSyncService: ICloudConnectionSyncService
     private let isCleanupLaunch: Bool
 
     init() {
         self.isCleanupLaunch = ProcessInfo.processInfo.arguments.contains(Self.cleanupFileProviderStateArgument)
-        self.storage = SharedStorage.withLegacyMigration()
-        self.credentialProvider = MirroredCredentialProvider(primary: KeychainService())
+        let storage = SharedStorage.withLegacyMigration()
+        let credentialProvider = MirroredCredentialProvider(primary: KeychainService())
+        let iCloudSyncService = ICloudConnectionSyncService(storage: storage)
+        self.storage = storage
+        self.credentialProvider = credentialProvider
+        self.iCloudSyncService = iCloudSyncService
         self.mountProvider = FileProviderMountProvider()
-        let credentialProvider = self.credentialProvider
         let registry = BackendRegistry.shared
         registry.registerAllBuiltIns(
             sftpFactory: { config, credential in
@@ -60,10 +65,25 @@ struct MFuseApp: App {
             }
         )
         let manager = ConnectionManager(
-            storage: self.storage,
-            credentialProvider: self.credentialProvider,
+            storage: storage,
+            credentialProvider: credentialProvider,
             registry: registry
         )
+        manager.onLocalConnectionsDidChange = { _ in
+            guard SharedAppSettings.iCloudSyncEnabled else {
+                return
+            }
+            Task { @MainActor in
+                do {
+                    let result = try await iCloudSyncService.synchronize()
+                    if result.didUpdateLocalSnapshot {
+                        await manager.reloadConnectionsFromStorage()
+                    }
+                } catch {
+                    NSLog("MFuse iCloud sync failed after local config change: %@", error.localizedDescription)
+                }
+            }
+        }
         AppDelegate.shutdownHandler = { [manager] in
             await manager.shutdown()
         }
@@ -85,7 +105,11 @@ struct MFuseApp: App {
             }
         }
         _connectionManager = StateObject(wrappedValue: manager)
-        _appSettings = StateObject(wrappedValue: AppSettingsStore())
+        _appSettings = StateObject(wrappedValue: AppSettingsStore(
+            storage: storage,
+            credentialProvider: credentialProvider,
+            iCloudSyncService: iCloudSyncService
+        ))
     }
 
     var body: some Scene {
@@ -98,6 +122,15 @@ struct MFuseApp: App {
                 .frame(minWidth: 700, minHeight: 450)
                 .task {
                     await performInitialSetupIfNeeded()
+                }
+                .onChange(of: scenePhase) { _, newPhase in
+                    guard newPhase == .active else { return }
+                    Task {
+                        await appSettings.refreshICloudSyncStatus()
+                        if await appSettings.performBackgroundSyncIfNeeded() {
+                            await connectionManager.reloadConnectionsFromStorage()
+                        }
+                    }
                 }
         }
         .windowStyle(.titleBar)
@@ -137,6 +170,10 @@ struct MFuseApp: App {
         didPerformInitialSetup = true
 
         guard isCleanupLaunch else {
+            await appSettings.refreshICloudSyncStatus()
+            if await appSettings.performBackgroundSyncIfNeeded() {
+                await connectionManager.reloadConnectionsFromStorage()
+            }
             await connectionManager.syncCredentialSnapshots()
             do {
                 try await domainManager.syncDomains()
@@ -249,4 +286,5 @@ extension EnvironmentValues {
 extension Notification.Name {
     static let newConnection = Notification.Name("com.lollipopkit.mfuse.newConnection")
     static let refreshConnections = Notification.Name("com.lollipopkit.mfuse.refreshConnections")
+    static let connectionStorageDidRefresh = Notification.Name("com.lollipopkit.mfuse.connectionStorageDidRefresh")
 }

--- a/MFuse/Services/AppSettingsStore.swift
+++ b/MFuse/Services/AppSettingsStore.swift
@@ -144,6 +144,24 @@ final class AppSettingsStore: ObservableObject {
         setPersistedICloudSyncEnabled(recoveredEnabled)
     }
 
+    private func recoverICloudSyncStateAfterEnableRollbackFailure(connectionIDs: [UUID]) async {
+        let recoveredEnabled: Bool
+
+        do {
+            let credentialSyncState = try await credentialProvider.credentialSyncState(for: connectionIDs)
+            switch credentialSyncState {
+            case .synchronizable:
+                recoveredEnabled = true
+            case .local, .mixed:
+                recoveredEnabled = false
+            }
+        } catch {
+            recoveredEnabled = false
+        }
+
+        setPersistedICloudSyncEnabled(recoveredEnabled)
+    }
+
     private func applyICloudSync(_ enabled: Bool) async {
         guard !isUpdatingICloudSync else {
             return
@@ -186,6 +204,7 @@ final class AppSettingsStore: ObservableObject {
                     let rollbackErrorDescription = error.localizedDescription
                     let combinedErrorDescription =
                         "Failed to enable iCloud Sync: \(syncErrorDescription) Rollback failed: \(rollbackErrorDescription)"
+                    await recoverICloudSyncStateAfterEnableRollbackFailure(connectionIDs: connectionIDs)
                     NSLog("%@", combinedErrorDescription)
                     errorMessage = combinedErrorDescription
                 }

--- a/MFuse/Services/AppSettingsStore.swift
+++ b/MFuse/Services/AppSettingsStore.swift
@@ -1,14 +1,39 @@
 import Foundation
+import MFuseCore
 import ServiceManagement
 
 @MainActor
 final class AppSettingsStore: ObservableObject {
     @Published private(set) var launchAtLoginEnabled = false
     @Published private(set) var launchAtLoginStatusDescription = ""
+    @Published private(set) var iCloudSyncEnabled = SharedAppSettings.iCloudSyncEnabled
+    @Published private(set) var iCloudSyncStatusDescription = ""
+    @Published private(set) var iCloudSyncAvailabilityDescription = ""
+    @Published private(set) var iCloudSyncCanBeEnabled = false
+    @Published private(set) var isUpdatingICloudSync = false
     @Published var errorMessage: String?
 
-    init() {
+    private let storage: SharedStorage
+    private let credentialProvider: MirroredCredentialProvider
+    private let iCloudSyncService: ICloudConnectionSyncService
+    private var currentICloudAvailability = ICloudSyncAvailability(
+        isDriveAvailable: false,
+        isKeychainAvailable: false,
+        unavailableReasons: []
+    )
+
+    init(
+        storage: SharedStorage,
+        credentialProvider: MirroredCredentialProvider,
+        iCloudSyncService: ICloudConnectionSyncService
+    ) {
+        self.storage = storage
+        self.credentialProvider = credentialProvider
+        self.iCloudSyncService = iCloudSyncService
         refreshLaunchAtLoginStatus()
+        Task {
+            await refreshICloudSyncStatus()
+        }
     }
 
     var versionString: String {
@@ -17,6 +42,10 @@ final class AppSettingsStore: ObservableObject {
 
     var buildString: String {
         Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "Unknown"
+    }
+
+    var iCloudSyncToggleDisabled: Bool {
+        isUpdatingICloudSync || (!iCloudSyncCanBeEnabled && !iCloudSyncEnabled)
     }
 
     func refreshLaunchAtLoginStatus() {
@@ -37,6 +66,24 @@ final class AppSettingsStore: ObservableObject {
         }
     }
 
+    func refreshICloudSyncStatus() async {
+        currentICloudAvailability = await iCloudSyncService.availability()
+        iCloudSyncEnabled = SharedAppSettings.iCloudSyncEnabled
+        iCloudSyncCanBeEnabled = currentICloudAvailability.canEnableSync
+
+        if iCloudSyncEnabled {
+            iCloudSyncStatusDescription = "Syncs connection configs and credentials across devices with iCloud."
+        } else {
+            iCloudSyncStatusDescription = "Keep connection configs and credentials in sync across devices with iCloud."
+        }
+
+        if currentICloudAvailability.canEnableSync {
+            iCloudSyncAvailabilityDescription = "Requires both iCloud Drive and iCloud Keychain."
+        } else {
+            iCloudSyncAvailabilityDescription = currentICloudAvailability.unavailableReasons.joined(separator: " ")
+        }
+    }
+
     func setLaunchAtLoginEnabled(_ enabled: Bool) {
         do {
             if enabled {
@@ -49,5 +96,71 @@ final class AppSettingsStore: ObservableObject {
             refreshLaunchAtLoginStatus()
             errorMessage = error.localizedDescription
         }
+    }
+
+    func setICloudSyncEnabled(_ enabled: Bool) {
+        Task {
+            await applyICloudSync(enabled)
+        }
+    }
+
+    func performBackgroundSyncIfNeeded() async -> Bool {
+        guard SharedAppSettings.iCloudSyncEnabled else {
+            return false
+        }
+
+        do {
+            let result = try await iCloudSyncService.synchronize()
+            return result.didUpdateLocalSnapshot
+        } catch {
+            NSLog("MFuse iCloud sync failed: %@", error.localizedDescription)
+            return false
+        }
+    }
+
+    private func applyICloudSync(_ enabled: Bool) async {
+        guard !isUpdatingICloudSync else {
+            return
+        }
+        isUpdatingICloudSync = true
+        defer { isUpdatingICloudSync = false }
+
+        await refreshICloudSyncStatus()
+        let connectionIDs = storage.loadConnections().map(\.id)
+
+        if enabled {
+            guard currentICloudAvailability.canEnableSync else {
+                iCloudSyncEnabled = false
+                errorMessage = currentICloudAvailability.unavailableReasons.joined(separator: " ")
+                return
+            }
+
+            do {
+                try await credentialProvider.setSynchronizableEnabled(true, connectionIDs: connectionIDs)
+                let result = try await iCloudSyncService.synchronize()
+                SharedAppSettings.setICloudSyncEnabled(true)
+                iCloudSyncEnabled = true
+                if result.didUpdateLocalSnapshot {
+                    NotificationCenter.default.post(name: .connectionStorageDidRefresh, object: nil)
+                }
+            } catch {
+                try? await credentialProvider.setSynchronizableEnabled(false, connectionIDs: connectionIDs)
+                SharedAppSettings.setICloudSyncEnabled(false)
+                iCloudSyncEnabled = false
+                errorMessage = error.localizedDescription
+            }
+        } else {
+            do {
+                try await credentialProvider.setSynchronizableEnabled(false, connectionIDs: connectionIDs)
+                SharedAppSettings.setICloudSyncEnabled(false)
+                iCloudSyncEnabled = false
+            } catch {
+                SharedAppSettings.setICloudSyncEnabled(true)
+                iCloudSyncEnabled = true
+                errorMessage = error.localizedDescription
+            }
+        }
+
+        await refreshICloudSyncStatus()
     }
 }

--- a/MFuse/Services/AppSettingsStore.swift
+++ b/MFuse/Services/AppSettingsStore.swift
@@ -125,12 +125,20 @@ final class AppSettingsStore: ObservableObject {
 
     private func recoverICloudSyncStateAfterDisableFailure(connectionIDs: [UUID]) async {
         let recoveredEnabled: Bool
+        let persistedEnabled = SharedAppSettings.iCloudSyncEnabled
 
         do {
             let credentialSyncState = try await credentialProvider.credentialSyncState(for: connectionIDs)
-            recoveredEnabled = credentialSyncState == .synchronizable
+            switch credentialSyncState {
+            case .synchronizable:
+                recoveredEnabled = true
+            case .local:
+                recoveredEnabled = false
+            case .mixed:
+                recoveredEnabled = persistedEnabled
+            }
         } catch {
-            recoveredEnabled = false
+            recoveredEnabled = persistedEnabled
         }
 
         setPersistedICloudSyncEnabled(recoveredEnabled)
@@ -140,6 +148,7 @@ final class AppSettingsStore: ObservableObject {
         guard !isUpdatingICloudSync else {
             return
         }
+        errorMessage = nil
         isUpdatingICloudSync = true
         defer { isUpdatingICloudSync = false }
 
@@ -167,9 +176,19 @@ final class AppSettingsStore: ObservableObject {
                     NotificationCenter.default.post(name: .connectionStorageDidRefresh, object: nil)
                 }
             } catch {
-                try? await credentialProvider.setSynchronizableEnabled(false, connectionIDs: connectionIDs)
-                setPersistedICloudSyncEnabled(false)
-                errorMessage = error.localizedDescription
+                let syncErrorDescription = error.localizedDescription
+
+                do {
+                    try await credentialProvider.setSynchronizableEnabled(false, connectionIDs: connectionIDs)
+                    setPersistedICloudSyncEnabled(false)
+                    errorMessage = syncErrorDescription
+                } catch {
+                    let rollbackErrorDescription = error.localizedDescription
+                    let combinedErrorDescription =
+                        "Failed to enable iCloud Sync: \(syncErrorDescription) Rollback failed: \(rollbackErrorDescription)"
+                    NSLog("%@", combinedErrorDescription)
+                    errorMessage = combinedErrorDescription
+                }
             }
         } else {
             do {

--- a/MFuse/Services/AppSettingsStore.swift
+++ b/MFuse/Services/AppSettingsStore.swift
@@ -118,6 +118,24 @@ final class AppSettingsStore: ObservableObject {
         }
     }
 
+    private func setPersistedICloudSyncEnabled(_ enabled: Bool) {
+        SharedAppSettings.setICloudSyncEnabled(enabled)
+        iCloudSyncEnabled = enabled
+    }
+
+    private func recoverICloudSyncStateAfterDisableFailure(connectionIDs: [UUID]) async {
+        let recoveredEnabled: Bool
+
+        do {
+            let credentialSyncState = try await credentialProvider.credentialSyncState(for: connectionIDs)
+            recoveredEnabled = credentialSyncState == .synchronizable
+        } catch {
+            recoveredEnabled = false
+        }
+
+        setPersistedICloudSyncEnabled(recoveredEnabled)
+    }
+
     private func applyICloudSync(_ enabled: Bool) async {
         guard !isUpdatingICloudSync else {
             return
@@ -126,7 +144,13 @@ final class AppSettingsStore: ObservableObject {
         defer { isUpdatingICloudSync = false }
 
         await refreshICloudSyncStatus()
-        let connectionIDs = storage.loadConnections().map(\.id)
+        let connectionIDs: [UUID]
+        do {
+            connectionIDs = try storage.loadConnections().map(\.id)
+        } catch {
+            errorMessage = error.localizedDescription
+            return
+        }
 
         if enabled {
             guard currentICloudAvailability.canEnableSync else {
@@ -137,26 +161,22 @@ final class AppSettingsStore: ObservableObject {
 
             do {
                 try await credentialProvider.setSynchronizableEnabled(true, connectionIDs: connectionIDs)
+                setPersistedICloudSyncEnabled(true)
                 let result = try await iCloudSyncService.synchronize()
-                SharedAppSettings.setICloudSyncEnabled(true)
-                iCloudSyncEnabled = true
                 if result.didUpdateLocalSnapshot {
                     NotificationCenter.default.post(name: .connectionStorageDidRefresh, object: nil)
                 }
             } catch {
                 try? await credentialProvider.setSynchronizableEnabled(false, connectionIDs: connectionIDs)
-                SharedAppSettings.setICloudSyncEnabled(false)
-                iCloudSyncEnabled = false
+                setPersistedICloudSyncEnabled(false)
                 errorMessage = error.localizedDescription
             }
         } else {
             do {
                 try await credentialProvider.setSynchronizableEnabled(false, connectionIDs: connectionIDs)
-                SharedAppSettings.setICloudSyncEnabled(false)
-                iCloudSyncEnabled = false
+                setPersistedICloudSyncEnabled(false)
             } catch {
-                SharedAppSettings.setICloudSyncEnabled(true)
-                iCloudSyncEnabled = true
+                await recoverICloudSyncStateAfterDisableFailure(connectionIDs: connectionIDs)
                 errorMessage = error.localizedDescription
             }
         }

--- a/MFuse/Views/ConnectionEditorSheet.swift
+++ b/MFuse/Views/ConnectionEditorSheet.swift
@@ -437,8 +437,10 @@ struct ConnectionEditorSheet: View {
     private func clearCredentialState(except method: AuthMethod) {
         switch method {
         case .password:
+            password = ""
             oauthToken = ""
             privateKeyPath = ""
+            privateKeyBookmark = ""
             s3AccessKeyID = ""
             s3SecretAccessKey = ""
         case .publicKey:
@@ -450,15 +452,18 @@ struct ConnectionEditorSheet: View {
             password = ""
             oauthToken = ""
             privateKeyPath = ""
+            privateKeyBookmark = ""
             s3AccessKeyID = ""
             s3SecretAccessKey = ""
         case .accessKey:
             password = ""
             oauthToken = ""
             privateKeyPath = ""
+            privateKeyBookmark = ""
         case .oauth:
             password = ""
             privateKeyPath = ""
+            privateKeyBookmark = ""
             s3AccessKeyID = ""
             s3SecretAccessKey = ""
         }

--- a/MFuse/Views/ConnectionEditorSheet.swift
+++ b/MFuse/Views/ConnectionEditorSheet.swift
@@ -437,14 +437,12 @@ struct ConnectionEditorSheet: View {
     private func clearCredentialState(except method: AuthMethod) {
         switch method {
         case .password:
-            password = ""
             oauthToken = ""
             privateKeyPath = ""
             privateKeyBookmark = ""
             s3AccessKeyID = ""
             s3SecretAccessKey = ""
         case .publicKey:
-            password = ""
             oauthToken = ""
             s3AccessKeyID = ""
             s3SecretAccessKey = ""

--- a/MFuse/Views/ContentView.swift
+++ b/MFuse/Views/ContentView.swift
@@ -75,6 +75,11 @@ struct ContentView: View {
                 }
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .connectionStorageDidRefresh)) { _ in
+            Task {
+                await connectionManager.reloadConnectionsFromStorage()
+            }
+        }
     }
 
     private var emptyState: some View {

--- a/MFuse/Views/ContentView.swift
+++ b/MFuse/Views/ContentView.swift
@@ -76,8 +76,16 @@ struct ContentView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: .connectionStorageDidRefresh)) { _ in
-            Task {
+            Task { @MainActor in
+                let selectedConnectionID = selectedConnection?.id
                 await connectionManager.reloadConnectionsFromStorage()
+                if let selectedConnectionID {
+                    selectedConnection = connectionManager.connections.first(where: {
+                        $0.id == selectedConnectionID
+                    })
+                } else {
+                    selectedConnection = nil
+                }
             }
         }
     }

--- a/MFuse/Views/SettingsView.swift
+++ b/MFuse/Views/SettingsView.swift
@@ -19,16 +19,41 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
+            Section("Sync") {
+                Toggle(
+                    "iCloud Sync",
+                    isOn: Binding(
+                        get: { appSettings.iCloudSyncEnabled },
+                        set: { appSettings.setICloudSyncEnabled($0) }
+                    )
+                )
+                .disabled(appSettings.iCloudSyncToggleDisabled)
+
+                Text(appSettings.iCloudSyncStatusDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(appSettings.iCloudSyncAvailabilityDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if appSettings.isUpdatingICloudSync {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
             Section("About") {
                 LabeledContent("Version", value: appSettings.versionString)
                 LabeledContent("Build", value: appSettings.buildString)
             }
         }
         .formStyle(.grouped)
-        .frame(width: 420, height: 220)
+        .frame(width: 460, height: 340)
         .padding(20)
         .task {
             appSettings.refreshLaunchAtLoginStatus()
+            await appSettings.refreshICloudSyncStatus()
         }
         .alert("Unable to Update Settings", isPresented: errorIsPresented) {
             Button("OK", role: .cancel) {

--- a/MFuseProvider/FileProviderExtension.swift
+++ b/MFuseProvider/FileProviderExtension.swift
@@ -95,6 +95,33 @@ final class FileProviderDomainVersionState: @unchecked Sendable {
     }
 }
 
+final class SharedCredentialStoreProvider: @unchecked Sendable {
+    private let lock = NSLock()
+    private var store: SharedCredentialStore
+
+    init(
+        syncMode: KeychainItemSyncMode = SharedAppSettings.iCloudSyncEnabled ? .synchronizable : .local
+    ) {
+        self.store = SharedCredentialStore(syncMode: syncMode)
+    }
+
+    func credential(for connectionID: UUID) throws -> Credential? {
+        let store = lock.withLock { self.store }
+        return try store.credential(for: connectionID)
+    }
+
+    func store(_ credential: Credential, for connectionID: UUID) throws {
+        let store = lock.withLock { self.store }
+        try store.store(credential, for: connectionID)
+    }
+
+    func replace(syncMode: KeychainItemSyncMode) {
+        lock.withLock {
+            self.store = SharedCredentialStore(syncMode: syncMode)
+        }
+    }
+}
+
 @Sendable
 func withOperationTimeout<T: Sendable>(
     seconds: Double,
@@ -125,11 +152,7 @@ public final class FileProviderExtension: NSObject, NSFileProviderReplicatedExte
     private static let bootstrapTransientRetryDelayNanoseconds: UInt64 = 750_000_000
     private static let contentCacheStoreRetryCount = 2
     private static let streamedReadChunkSize: UInt32 = 1_048_576
-    private static var sharedCredentialStore: SharedCredentialStore {
-        SharedCredentialStore(
-            syncMode: SharedAppSettings.iCloudSyncEnabled ? .synchronizable : .local
-        )
-    }
+    private static let sharedCredentialStoreProvider = SharedCredentialStoreProvider()
     private static let registerBackendsOnce: Void = {
         BackendRegistry.shared.registerAllBuiltIns(
             sftpFactory: { config, credential in
@@ -155,7 +178,7 @@ public final class FileProviderExtension: NSObject, NSFileProviderReplicatedExte
                     config: config,
                     credential: credential
                 ) { updatedCredential in
-                    try FileProviderExtension.sharedCredentialStore.store(updatedCredential, for: config.id)
+                    try FileProviderExtension.sharedCredentialStoreProvider.store(updatedCredential, for: config.id)
                 }
             }
         )
@@ -170,7 +193,18 @@ public final class FileProviderExtension: NSObject, NSFileProviderReplicatedExte
     public required init(domain: NSFileProviderDomain) {
         self.domain = domain
         super.init()
+        Self.swapCredentialStoreForCurrentSettings()
         Self.registerBackends()
+    }
+
+    static func swapCredentialStore(syncMode: KeychainItemSyncMode) {
+        sharedCredentialStoreProvider.replace(syncMode: syncMode)
+    }
+
+    static func swapCredentialStoreForCurrentSettings() {
+        swapCredentialStore(
+            syncMode: SharedAppSettings.iCloudSyncEnabled ? .synchronizable : .local
+        )
     }
 
     public var domainVersion: NSFileProviderDomainVersion {
@@ -658,7 +692,7 @@ public final class FileProviderExtension: NSObject, NSFileProviderReplicatedExte
     }
 
     private func requireCredential(for config: ConnectionConfig) async throws -> Credential {
-        let credential = try Self.sharedCredentialStore.credential(for: config.id) ?? Credential()
+        let credential = try Self.sharedCredentialStoreProvider.credential(for: config.id) ?? Credential()
 
         switch config.authMethod {
         case .password:

--- a/MFuseProvider/FileProviderExtension.swift
+++ b/MFuseProvider/FileProviderExtension.swift
@@ -125,7 +125,11 @@ public final class FileProviderExtension: NSObject, NSFileProviderReplicatedExte
     private static let bootstrapTransientRetryDelayNanoseconds: UInt64 = 750_000_000
     private static let contentCacheStoreRetryCount = 2
     private static let streamedReadChunkSize: UInt32 = 1_048_576
-    private static let sharedCredentialStore = SharedCredentialStore()
+    private static var sharedCredentialStore: SharedCredentialStore {
+        SharedCredentialStore(
+            syncMode: SharedAppSettings.iCloudSyncEnabled ? .synchronizable : .local
+        )
+    }
     private static let registerBackendsOnce: Void = {
         BackendRegistry.shared.registerAllBuiltIns(
             sftpFactory: { config, credential in

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
@@ -64,7 +64,14 @@ public final class ConnectionManager: ObservableObject {
         self.storage = storage
         self.credentialProvider = credentialProvider
         self.registry = registry
-        self.connections = storage.loadConnections()
+        do {
+            self.connections = try storage.loadConnections()
+        } catch {
+            self.connections = []
+            logger.error(
+                "Failed to load initial connections from storage: \(String(describing: error), privacy: .public)"
+            )
+        }
     }
 
     // MARK: - CRUD
@@ -471,13 +478,27 @@ public final class ConnectionManager: ObservableObject {
     }
 
     public func reloadConnectionsFromStorage() async {
-        let reloadedConnections = storage.loadConnections()
+        let reloadedConnections: [ConnectionConfig]
+        do {
+            reloadedConnections = try storage.loadConnections()
+        } catch {
+            logger.error(
+                "Failed to reload connections from storage: \(String(describing: error), privacy: .public)"
+            )
+            return
+        }
         let currentConnections = connections
         let currentIDs = Set(currentConnections.map(\.id))
         let reloadedIDs = Set(reloadedConnections.map(\.id))
+        var nextConnections = reloadedConnections
 
         for removedConfig in currentConnections where !reloadedIDs.contains(removedConfig.id) {
             await disconnect(removedConfig.id, using: removedConfig)
+            guard isCleanupComplete(for: removedConfig.id) else {
+                nextConnections.append(removedConfig)
+                continue
+            }
+
             states.removeValue(forKey: removedConfig.id)
             mountStates.removeValue(forKey: removedConfig.id)
             fileSystems.removeValue(forKey: removedConfig.id)
@@ -490,8 +511,8 @@ public final class ConnectionManager: ObservableObject {
             mountResolutionTasks.removeValue(forKey: removedConfig.id)
         }
 
-        connections = reloadedConnections
-        for config in reloadedConnections where !currentIDs.contains(config.id) {
+        connections = nextConnections
+        for config in nextConnections where !currentIDs.contains(config.id) {
             states[config.id] = .disconnected
         }
     }

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
@@ -46,6 +46,9 @@ public final class ConnectionManager: ObservableObject {
     /// Optional callback for mount state change notifications.
     public var onMountStateChange: ((ConnectionConfig, MountState) -> Void)?
 
+    /// Optional callback fired after local add/update/remove persistence succeeds.
+    public var onLocalConnectionsDidChange: (([ConnectionConfig]) -> Void)?
+
     private static let maxRetries = 5
     private static let baseDelay: UInt64 = 1_000_000_000 // 1 second in nanoseconds
     private static let mountURLRetryCount = 20
@@ -71,6 +74,7 @@ public final class ConnectionManager: ObservableObject {
         states[config.id] = .disconnected
         do {
             try storage.saveConnections(connections)
+            onLocalConnectionsDidChange?(connections)
         } catch {
             connections.removeAll { $0.id == config.id }
             states.removeValue(forKey: config.id)
@@ -84,6 +88,7 @@ public final class ConnectionManager: ObservableObject {
             connections[idx] = config
             do {
                 try storage.saveConnections(connections)
+                onLocalConnectionsDidChange?(connections)
             } catch {
                 connections[idx] = previous
                 throw error
@@ -165,6 +170,7 @@ public final class ConnectionManager: ObservableObject {
             )
         }
         connectionGenerations.removeValue(forKey: config.id)
+        onLocalConnectionsDidChange?(connections)
     }
 
     // MARK: - Connection lifecycle
@@ -300,6 +306,10 @@ public final class ConnectionManager: ObservableObject {
     }
 
     public func disconnect(_ id: UUID) async {
+        await disconnect(id, using: nil)
+    }
+
+    private func disconnect(_ id: UUID, using configOverride: ConnectionConfig?) async {
         advanceConnectionGeneration(for: id)
         if inFlightConnectionIDs.contains(id) {
             interruptedConnectionIDs.insert(id)
@@ -309,7 +319,7 @@ public final class ConnectionManager: ObservableObject {
         mountResolutionTasks[id]?.cancel()
         mountResolutionTasks.removeValue(forKey: id)
 
-        let config = connections.first(where: { $0.id == id })
+        let config = configOverride ?? connections.first(where: { $0.id == id })
         var cleanupFailures: [String] = []
         var didDisconnectFileSystem = false
 
@@ -358,9 +368,7 @@ public final class ConnectionManager: ObservableObject {
         fileSystems.removeValue(forKey: id)
         states[id] = .disconnected
         if let config {
-            if mountProvider != nil {
-                setMountState(.unmounted, for: config)
-            }
+            setMountState(.unmounted, for: config)
             onStateChange?(config, .disconnected)
         }
     }
@@ -459,6 +467,32 @@ public final class ConnectionManager: ObservableObject {
                     "Failed to sync credential snapshot for \(config.domainIdentifier, privacy: .public): \(String(describing: error), privacy: .public)"
                 )
             }
+        }
+    }
+
+    public func reloadConnectionsFromStorage() async {
+        let reloadedConnections = storage.loadConnections()
+        let currentConnections = connections
+        let currentIDs = Set(currentConnections.map(\.id))
+        let reloadedIDs = Set(reloadedConnections.map(\.id))
+
+        for removedConfig in currentConnections where !reloadedIDs.contains(removedConfig.id) {
+            await disconnect(removedConfig.id, using: removedConfig)
+            states.removeValue(forKey: removedConfig.id)
+            mountStates.removeValue(forKey: removedConfig.id)
+            fileSystems.removeValue(forKey: removedConfig.id)
+            connectionGenerations.removeValue(forKey: removedConfig.id)
+            inFlightConnectionIDs.remove(removedConfig.id)
+            interruptedConnectionIDs.remove(removedConfig.id)
+            reconnectTasks[removedConfig.id]?.cancel()
+            reconnectTasks.removeValue(forKey: removedConfig.id)
+            mountResolutionTasks[removedConfig.id]?.cancel()
+            mountResolutionTasks.removeValue(forKey: removedConfig.id)
+        }
+
+        connections = reloadedConnections
+        for config in reloadedConnections where !currentIDs.contains(config.id) {
+            states[config.id] = .disconnected
         }
     }
 
@@ -733,7 +767,7 @@ public final class ConnectionManager: ObservableObject {
 
     private func isCleanupComplete(for id: UUID) -> Bool {
         let connectionIsDisconnected = states[id]?.isConnected != true
-        let mountIsStopped = mountState(for: id) == .unmounted
+        let mountIsStopped = mountProvider == nil || mountState(for: id) == .unmounted
 
         return connectionIsDisconnected
             && mountIsStopped

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
@@ -301,7 +301,7 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
         let deleteStatus = SecItemDelete(query as CFDictionary)
         let deleteSucceeded = deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound
 
-        return readStatus == errSecSuccess && deleteSucceeded && result as? Data != nil
+        return readStatus == errSecSuccess && deleteSucceeded && result is Data
     }
 }
 

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Security
 
+public enum KeychainItemSyncMode: Sendable, Equatable {
+    case local
+    case synchronizable
+}
+
 /// Keychain-backed credential storage using the shared access group
 /// so both the app and File Provider extension can access credentials.
 public final class KeychainService: CredentialProvider, @unchecked Sendable {
@@ -9,14 +14,17 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
     private let accessGroup: String?
     private let allowLegacyMigration: Bool
     private let legacyAccessGroups: [String]
+    public let syncMode: KeychainItemSyncMode
     private var usesDataProtectionKeychain: Bool { accessGroup != nil }
 
     public init(
         accessGroup: String? = AppGroupConstants.keychainAccessGroup,
+        syncMode: KeychainItemSyncMode = SharedAppSettings.iCloudSyncEnabled ? .synchronizable : .local,
         allowLegacyMigration: Bool = true,
         legacyAccessGroups: [String] = [AppGroupConstants.legacyKeychainAccessGroup].compactMap { $0 }
     ) {
         self.accessGroup = accessGroup
+        self.syncMode = syncMode
         self.allowLegacyMigration = allowLegacyMigration
         self.legacyAccessGroups = legacyAccessGroups.filter { $0 != accessGroup }
     }
@@ -246,6 +254,9 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
         if useDataProtectionKeychain {
             query[kSecUseDataProtectionKeychain as String] = true
         }
+        if syncMode == .synchronizable {
+            query[kSecAttrSynchronizable as String] = kCFBooleanTrue
+        }
         return query
     }
 
@@ -253,6 +264,41 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
         let msg = SecCopyErrorMessageString(status, nil) as String? ?? "Unknown Keychain error (\(status))"
         return NSError(domain: NSOSStatusErrorDomain, code: Int(status),
                        userInfo: [NSLocalizedDescriptionKey: msg])
+    }
+
+    public static func isSynchronizableKeychainAvailable(
+        accessGroup: String? = AppGroupConstants.keychainAccessGroup
+    ) -> Bool {
+        let probeAccount = "probe.\(UUID().uuidString)"
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "com.lollipopkit.mfuse.credentials.probe",
+            kSecAttrAccount as String: probeAccount,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecAttrSynchronizable as String: kCFBooleanTrue as Any,
+            kSecValueData as String: Data("probe".utf8),
+        ]
+        if let accessGroup {
+            query[kSecAttrAccessGroup as String] = accessGroup
+            query[kSecUseDataProtectionKeychain as String] = true
+        }
+
+        let addStatus = SecItemAdd(query as CFDictionary, nil)
+        guard addStatus == errSecSuccess || addStatus == errSecDuplicateItem else {
+            return false
+        }
+
+        var readQuery = query
+        readQuery[kSecValueData as String] = nil
+        readQuery[kSecReturnData as String] = true
+        readQuery[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: AnyObject?
+        let readStatus = SecItemCopyMatching(readQuery as CFDictionary, &result)
+
+        let deleteStatus = SecItemDelete(query as CFDictionary)
+        let deleteSucceeded = deleteStatus == errSecSuccess || deleteStatus == errSecItemNotFound
+
+        return readStatus == errSecSuccess && deleteSucceeded && result as? Data != nil
     }
 }
 

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
@@ -91,10 +91,9 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
 
     private func migrateLegacyKeychainDataIfNeeded(account: String) throws -> Data? {
         for legacyAccessGroup in legacyAccessGroups {
-            guard let legacyData = try readKeychainData(
+            guard let legacyData = try readLegacyKeychainData(
                 account: account,
-                accessGroup: legacyAccessGroup,
-                useDataProtectionKeychain: true
+                accessGroup: legacyAccessGroup
             ) else {
                 continue
             }
@@ -104,11 +103,7 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
                 account: account,
                 useDataProtectionKeychain: true
             )
-            try deleteKeychainData(
-                account: account,
-                accessGroup: legacyAccessGroup,
-                useDataProtectionKeychain: true
-            )
+            try deleteLegacyKeychainData(account: account, accessGroup: legacyAccessGroup)
             return legacyData
         }
 
@@ -120,22 +115,47 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
             return
         }
         for legacyAccessGroup in legacyAccessGroups {
-            try? deleteKeychainData(
-                account: account,
-                accessGroup: legacyAccessGroup,
-                useDataProtectionKeychain: true
-            )
+            try? deleteLegacyKeychainData(account: account, accessGroup: legacyAccessGroup)
         }
     }
 
     private func deleteLegacyKeychainData(account: String) throws {
         for legacyAccessGroup in legacyAccessGroups {
-            try deleteKeychainData(
-                account: account,
-                accessGroup: legacyAccessGroup,
-                useDataProtectionKeychain: true
-            )
+            try deleteLegacyKeychainData(account: account, accessGroup: legacyAccessGroup)
         }
+    }
+
+    private func readLegacyKeychainData(account: String, accessGroup: String) throws -> Data? {
+        if let localData = try readKeychainData(
+            account: account,
+            accessGroup: accessGroup,
+            useDataProtectionKeychain: true,
+            syncModeOverride: .local
+        ) {
+            return localData
+        }
+
+        return try readKeychainData(
+            account: account,
+            accessGroup: accessGroup,
+            useDataProtectionKeychain: true,
+            syncModeOverride: .synchronizable
+        )
+    }
+
+    private func deleteLegacyKeychainData(account: String, accessGroup: String) throws {
+        try deleteKeychainData(
+            account: account,
+            accessGroup: accessGroup,
+            useDataProtectionKeychain: true,
+            syncModeOverride: .local
+        )
+        try deleteKeychainData(
+            account: account,
+            accessGroup: accessGroup,
+            useDataProtectionKeychain: true,
+            syncModeOverride: .synchronizable
+        )
     }
 
     private func readKeychainData(account: String, useDataProtectionKeychain: Bool) throws -> Data? {
@@ -201,12 +221,14 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
     private func readKeychainData(
         account: String,
         accessGroup: String?,
-        useDataProtectionKeychain: Bool
+        useDataProtectionKeychain: Bool,
+        syncModeOverride: KeychainItemSyncMode? = nil
     ) throws -> Data? {
         var query = baseQuery(
             account: account,
             accessGroup: accessGroup,
-            useDataProtectionKeychain: useDataProtectionKeychain
+            useDataProtectionKeychain: useDataProtectionKeychain,
+            syncModeOverride: syncModeOverride
         )
         query[kSecReturnData as String] = true
         query[kSecMatchLimit as String] = kSecMatchLimitOne
@@ -225,12 +247,14 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
     private func deleteKeychainData(
         account: String,
         accessGroup: String?,
-        useDataProtectionKeychain: Bool
+        useDataProtectionKeychain: Bool,
+        syncModeOverride: KeychainItemSyncMode? = nil
     ) throws {
         let query = baseQuery(
             account: account,
             accessGroup: accessGroup,
-            useDataProtectionKeychain: useDataProtectionKeychain
+            useDataProtectionKeychain: useDataProtectionKeychain,
+            syncModeOverride: syncModeOverride
         )
         let status = SecItemDelete(query as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
@@ -241,7 +265,8 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
     private func baseQuery(
         account: String,
         accessGroup: String?,
-        useDataProtectionKeychain: Bool
+        useDataProtectionKeychain: Bool,
+        syncModeOverride: KeychainItemSyncMode? = nil
     ) -> [String: Any] {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -254,7 +279,7 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
         if useDataProtectionKeychain {
             query[kSecUseDataProtectionKeychain as String] = true
         }
-        switch syncMode {
+        switch syncModeOverride ?? syncMode {
         case .local:
             query[kSecAttrSynchronizable as String] = kCFBooleanFalse
         case .synchronizable:

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
@@ -254,7 +254,10 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
         if useDataProtectionKeychain {
             query[kSecUseDataProtectionKeychain as String] = true
         }
-        if syncMode == .synchronizable {
+        switch syncMode {
+        case .local:
+            query[kSecAttrSynchronizable as String] = kCFBooleanFalse
+        case .synchronizable:
             query[kSecAttrSynchronizable as String] = kCFBooleanTrue
         }
         return query

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/KeychainService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Security
 
-public enum KeychainItemSyncMode: Sendable, Equatable {
+public enum KeychainItemSyncMode: Sendable, Equatable, Hashable {
     case local
     case synchronizable
 }
@@ -279,7 +279,7 @@ public final class KeychainService: CredentialProvider, @unchecked Sendable {
             kSecAttrAccount as String: probeAccount,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
             kSecAttrSynchronizable as String: kCFBooleanTrue as Any,
-            kSecValueData as String: Data("probe".utf8),
+            kSecValueData as String: Data("probe".utf8)
         ]
         if let accessGroup {
             query[kSecAttrAccessGroup as String] = accessGroup

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
@@ -17,6 +17,37 @@ public enum MirroredCredentialSyncState: Sendable, Equatable {
     case mixed
 }
 
+private actor MirroredCredentialOperationBarrier {
+    private var isRunning = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func withExclusive<T>(_ operation: () async throws -> T) async throws -> T {
+        await acquire()
+        defer { release() }
+        return try await operation()
+    }
+
+    private func acquire() async {
+        guard isRunning else {
+            isRunning = true
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    private func release() {
+        if let next = waiters.first {
+            waiters.removeFirst()
+            next.resume()
+        } else {
+            isRunning = false
+        }
+    }
+}
+
 /// Uses Keychain as the app-facing credential store while mirroring credentials
 /// into the shared credential store used by the File Provider extension.
 public final class MirroredCredentialProvider: CredentialProvider, @unchecked Sendable {
@@ -30,6 +61,7 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     }
 
     private let lock = NSLock()
+    private let operationBarrier = MirroredCredentialOperationBarrier()
     private let primaryFactory: @Sendable (KeychainItemSyncMode) -> KeychainService
     private let sharedStoreFactory: @Sendable (KeychainItemSyncMode) -> SharedCredentialStore
     private let customCredentialExistenceProbe: (@Sendable (KeychainItemSyncMode, UUID) async throws -> Bool)?
@@ -63,127 +95,135 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     }
 
     public func credential(for connectionID: UUID) async throws -> Credential? {
-        let (primary, sharedStore) = storesSnapshot()
-        let primaryCredential = try await primary.credential(for: connectionID)
-        if let primaryCredential {
-            do {
-                try sharedStore.store(primaryCredential, for: connectionID)
-            } catch {
-                // Best-effort mirror repair for the File Provider extension.
-            }
-            return primaryCredential
+        try await operationBarrier.withExclusive {
+            let (primary, sharedStore) = storesSnapshot()
+            return try await resolveCredential(
+                for: connectionID,
+                primary: primary,
+                sharedStore: sharedStore
+            )
         }
-
-        return try sharedStore.credential(for: connectionID)
     }
 
     public func store(_ credential: Credential, for connectionID: UUID) async throws {
-        let (primary, sharedStore) = storesSnapshot()
-        try await primary.store(credential, for: connectionID)
-        try sharedStore.store(credential, for: connectionID)
+        try await operationBarrier.withExclusive {
+            let (primary, sharedStore) = storesSnapshot()
+            try await primary.store(credential, for: connectionID)
+            try sharedStore.store(credential, for: connectionID)
+        }
     }
 
     public func delete(for connectionID: UUID) async throws {
-        let (primary, sharedStore) = storesSnapshot()
-        try await primary.delete(for: connectionID)
-        try sharedStore.delete(for: connectionID)
+        try await operationBarrier.withExclusive {
+            let (primary, sharedStore) = storesSnapshot()
+            try await primary.delete(for: connectionID)
+            try sharedStore.delete(for: connectionID)
+        }
     }
 
     public func credentialSyncState(for connectionIDs: [UUID]) async throws -> MirroredCredentialSyncState {
-        guard !connectionIDs.isEmpty else {
+        try await operationBarrier.withExclusive {
+            guard !connectionIDs.isEmpty else {
+                return syncMode == .synchronizable ? .synchronizable : .local
+            }
+
+            var foundLocalCredential = false
+            var foundSynchronizableCredential = false
+
+            for connectionID in connectionIDs {
+                if try await credentialExists(in: .local, for: connectionID) {
+                    foundLocalCredential = true
+                }
+
+                if try await credentialExists(in: .synchronizable, for: connectionID) {
+                    foundSynchronizableCredential = true
+                }
+
+                if foundLocalCredential && foundSynchronizableCredential {
+                    return .mixed
+                }
+            }
+
+            if foundSynchronizableCredential {
+                return .synchronizable
+            }
+
+            if foundLocalCredential {
+                return .local
+            }
+
             return syncMode == .synchronizable ? .synchronizable : .local
         }
-
-        var foundLocalCredential = false
-        var foundSynchronizableCredential = false
-
-        for connectionID in connectionIDs {
-            if try await credentialExists(in: .local, for: connectionID) {
-                foundLocalCredential = true
-            }
-
-            if try await credentialExists(in: .synchronizable, for: connectionID) {
-                foundSynchronizableCredential = true
-            }
-
-            if foundLocalCredential && foundSynchronizableCredential {
-                return .mixed
-            }
-        }
-
-        if foundSynchronizableCredential {
-            return .synchronizable
-        }
-
-        if foundLocalCredential {
-            return .local
-        }
-
-        return syncMode == .synchronizable ? .synchronizable : .local
     }
 
     public func setSynchronizableEnabled(_ enabled: Bool, connectionIDs: [UUID]) async throws {
-        let targetMode: KeychainItemSyncMode = enabled ? .synchronizable : .local
-        let (sourcePrimary, sourceSharedStore) = storesSnapshot()
-        guard let keychainPrimary = sourcePrimary as? KeychainService else {
-            throw MirroredCredentialProviderError.unsupportedPrimaryProvider
-        }
-        guard keychainPrimary.syncMode != targetMode else {
-            return
-        }
-
-        let targetPrimary = primaryFactory(targetMode)
-        let targetSharedStore = sharedStoreFactory(targetMode)
-
-        var credentialsToMove: [UUID: Credential] = [:]
-        for connectionID in connectionIDs {
-            if let credential = try await credential(for: connectionID) {
-                credentialsToMove[connectionID] = credential
+        try await operationBarrier.withExclusive {
+            let targetMode: KeychainItemSyncMode = enabled ? .synchronizable : .local
+            let (sourcePrimary, sourceSharedStore) = storesSnapshot()
+            guard let keychainPrimary = sourcePrimary as? KeychainService else {
+                throw MirroredCredentialProviderError.unsupportedPrimaryProvider
             }
-        }
-
-        do {
-            for (connectionID, credential) in credentialsToMove {
-                try await targetPrimary.store(credential, for: connectionID)
-                try targetSharedStore.store(credential, for: connectionID)
+            guard keychainPrimary.syncMode != targetMode else {
+                return
             }
-        } catch {
-            try? await rollbackModeTransition(context: ModeTransitionContext(
-                credentialsToMove: credentialsToMove,
-                sourcePrimary: sourcePrimary,
-                sourceSharedStore: sourceSharedStore,
-                targetPrimary: targetPrimary,
-                targetSharedStore: targetSharedStore,
-                connectionIDs: connectionIDs
-            ))
-            throw error
-        }
 
-        for connectionID in connectionIDs {
-            do {
-                try await sourcePrimary.delete(for: connectionID)
-            } catch {
-                NSLog(
-                    "MFuse credential migration cleanup failed for source primary item %@: %@",
-                    connectionID.uuidString,
-                    error.localizedDescription
-                )
+            let targetPrimary = primaryFactory(targetMode)
+            let targetSharedStore = sharedStoreFactory(targetMode)
+
+            var credentialsToMove: [UUID: Credential] = [:]
+            for connectionID in connectionIDs {
+                if let credential = try await resolveCredential(
+                    for: connectionID,
+                    primary: sourcePrimary,
+                    sharedStore: sourceSharedStore
+                ) {
+                    credentialsToMove[connectionID] = credential
+                }
             }
 
             do {
-                try sourceSharedStore.delete(for: connectionID)
+                for (connectionID, credential) in credentialsToMove {
+                    try await targetPrimary.store(credential, for: connectionID)
+                    try targetSharedStore.store(credential, for: connectionID)
+                }
             } catch {
-                NSLog(
-                    "MFuse credential migration cleanup failed for source shared item %@: %@",
-                    connectionID.uuidString,
-                    error.localizedDescription
-                )
+                try? await rollbackModeTransition(context: ModeTransitionContext(
+                    credentialsToMove: credentialsToMove,
+                    sourcePrimary: sourcePrimary,
+                    sourceSharedStore: sourceSharedStore,
+                    targetPrimary: targetPrimary,
+                    targetSharedStore: targetSharedStore,
+                    connectionIDs: connectionIDs
+                ))
+                throw error
             }
-        }
 
-        lock.withLock {
-            primary = targetPrimary
-            sharedStore = targetSharedStore
+            for connectionID in connectionIDs {
+                do {
+                    try await sourcePrimary.delete(for: connectionID)
+                } catch {
+                    NSLog(
+                        "MFuse credential migration cleanup failed for source primary item %@: %@",
+                        connectionID.uuidString,
+                        error.localizedDescription
+                    )
+                }
+
+                do {
+                    try sourceSharedStore.delete(for: connectionID)
+                } catch {
+                    NSLog(
+                        "MFuse credential migration cleanup failed for source shared item %@: %@",
+                        connectionID.uuidString,
+                        error.localizedDescription
+                    )
+                }
+            }
+
+            lock.withLock {
+                primary = targetPrimary
+                sharedStore = targetSharedStore
+            }
         }
     }
 
@@ -203,6 +243,24 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
         lock.withLock {
             (primary, sharedStore)
         }
+    }
+
+    private func resolveCredential(
+        for connectionID: UUID,
+        primary: CredentialProvider,
+        sharedStore: SharedCredentialStore
+    ) async throws -> Credential? {
+        let primaryCredential = try await primary.credential(for: connectionID)
+        if let primaryCredential {
+            do {
+                try sharedStore.store(primaryCredential, for: connectionID)
+            } catch {
+                // Best-effort mirror repair for the File Provider extension.
+            }
+            return primaryCredential
+        }
+
+        return try sharedStore.credential(for: connectionID)
     }
 
     private func credentialExists(in mode: KeychainItemSyncMode, for connectionID: UUID) async throws -> Bool {

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
@@ -80,7 +80,7 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
         let sourceSharedStore: SharedCredentialStore
         let targetPrimary: KeychainService
         let targetSharedStore: SharedCredentialStore
-        let connectionIDs: [UUID]
+        let writtenConnectionIDs: Set<UUID>
     }
 
     private let lock = NSLock()
@@ -139,8 +139,8 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     public func delete(for connectionID: UUID) async throws {
         try await operationBarrier.withExclusive {
             let (primary, sharedStore) = storesSnapshot()
-            try await primary.delete(for: connectionID)
             try sharedStore.delete(for: connectionID)
+            try await primary.delete(for: connectionID)
         }
     }
 
@@ -194,6 +194,7 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
             let targetSharedStore = sharedStoreFactory(targetMode)
 
             var credentialsToMove: [UUID: Credential] = [:]
+            var writtenConnectionIDs: Set<UUID> = []
             for connectionID in connectionIDs {
                 if let credential = try await resolveCredential(
                     for: connectionID,
@@ -207,7 +208,9 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
             do {
                 for (connectionID, credential) in credentialsToMove {
                     try await targetPrimary.store(credential, for: connectionID)
+                    writtenConnectionIDs.insert(connectionID)
                     try targetSharedStore.store(credential, for: connectionID)
+                    writtenConnectionIDs.insert(connectionID)
                 }
             } catch {
                 let originalError = error
@@ -217,7 +220,7 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
                     sourceSharedStore: sourceSharedStore,
                     targetPrimary: targetPrimary,
                     targetSharedStore: targetSharedStore,
-                    connectionIDs: connectionIDs
+                    writtenConnectionIDs: writtenConnectionIDs
                 )
 
                 do {
@@ -282,7 +285,7 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
             }
         }
 
-        for connectionID in context.connectionIDs {
+        for connectionID in context.writtenConnectionIDs {
             do {
                 try await context.targetPrimary.delete(for: connectionID)
             } catch {

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
@@ -11,6 +11,12 @@ public enum MirroredCredentialProviderError: Error, LocalizedError {
     }
 }
 
+public enum MirroredCredentialSyncState: Sendable, Equatable {
+    case local
+    case synchronizable
+    case mixed
+}
+
 /// Uses Keychain as the app-facing credential store while mirroring credentials
 /// into the shared credential store used by the File Provider extension.
 public final class MirroredCredentialProvider: CredentialProvider, @unchecked Sendable {
@@ -18,15 +24,36 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     private let lock = NSLock()
     private let primaryFactory: @Sendable (KeychainItemSyncMode) -> KeychainService
     private let sharedStoreFactory: @Sendable (KeychainItemSyncMode) -> SharedCredentialStore
+    private let credentialExistenceProbe: @Sendable (KeychainItemSyncMode, UUID) async throws -> Bool
     private var primary: CredentialProvider
     public private(set) var sharedStore: SharedCredentialStore
 
     public init(
         primary: CredentialProvider = KeychainService(),
-        sharedStore: SharedCredentialStore = SharedCredentialStore(allowLegacyKeychainMigration: true)
+        sharedStore: SharedCredentialStore = SharedCredentialStore(allowLegacyKeychainMigration: true),
+        primaryFactory: @escaping @Sendable (KeychainItemSyncMode) -> KeychainService = {
+            KeychainService(syncMode: $0)
+        },
+        sharedStoreFactory: @escaping @Sendable (KeychainItemSyncMode) -> SharedCredentialStore = {
+            SharedCredentialStore(syncMode: $0, allowLegacyKeychainMigration: true)
+        },
+        credentialExistenceProbe: (@Sendable (KeychainItemSyncMode, UUID) async throws -> Bool)? = nil
     ) {
-        self.primaryFactory = { KeychainService(syncMode: $0) }
-        self.sharedStoreFactory = { SharedCredentialStore(syncMode: $0, allowLegacyKeychainMigration: true) }
+        self.primaryFactory = primaryFactory
+        self.sharedStoreFactory = sharedStoreFactory
+        if let credentialExistenceProbe {
+            self.credentialExistenceProbe = credentialExistenceProbe
+        } else {
+            self.credentialExistenceProbe = { mode, connectionID in
+                let primary = primaryFactory(mode)
+                let sharedStore = sharedStoreFactory(mode)
+                if try await primary.credential(for: connectionID) != nil {
+                    return true
+                }
+
+                return try sharedStore.credential(for: connectionID) != nil
+            }
+        }
         self.primary = primary
         self.sharedStore = sharedStore
     }
@@ -64,6 +91,39 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
         try sharedStore.delete(for: connectionID)
     }
 
+    public func credentialSyncState(for connectionIDs: [UUID]) async throws -> MirroredCredentialSyncState {
+        guard !connectionIDs.isEmpty else {
+            return syncMode == .synchronizable ? .synchronizable : .local
+        }
+
+        var foundLocalCredential = false
+        var foundSynchronizableCredential = false
+
+        for connectionID in connectionIDs {
+            if try await credentialExistenceProbe(.local, connectionID) {
+                foundLocalCredential = true
+            }
+
+            if try await credentialExistenceProbe(.synchronizable, connectionID) {
+                foundSynchronizableCredential = true
+            }
+
+            if foundLocalCredential && foundSynchronizableCredential {
+                return .mixed
+            }
+        }
+
+        if foundSynchronizableCredential {
+            return .synchronizable
+        }
+
+        if foundLocalCredential {
+            return .local
+        }
+
+        return syncMode == .synchronizable ? .synchronizable : .local
+    }
+
     public func setSynchronizableEnabled(_ enabled: Bool, connectionIDs: [UUID]) async throws {
         let targetMode: KeychainItemSyncMode = enabled ? .synchronizable : .local
         let (sourcePrimary, sourceSharedStore) = storesSnapshot()
@@ -89,11 +149,6 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
                 try await targetPrimary.store(credential, for: connectionID)
                 try targetSharedStore.store(credential, for: connectionID)
             }
-
-            for connectionID in connectionIDs {
-                try await sourcePrimary.delete(for: connectionID)
-                try sourceSharedStore.delete(for: connectionID)
-            }
         } catch {
             try? await rollbackModeTransition(
                 credentialsToMove: credentialsToMove,
@@ -104,6 +159,28 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
                 connectionIDs: connectionIDs
             )
             throw error
+        }
+
+        for connectionID in connectionIDs {
+            do {
+                try await sourcePrimary.delete(for: connectionID)
+            } catch {
+                NSLog(
+                    "MFuse credential migration cleanup failed for source primary item %@: %@",
+                    connectionID.uuidString,
+                    error.localizedDescription
+                )
+            }
+
+            do {
+                try sourceSharedStore.delete(for: connectionID)
+            } catch {
+                NSLog(
+                    "MFuse credential migration cleanup failed for source shared item %@: %@",
+                    connectionID.uuidString,
+                    error.localizedDescription
+                )
+            }
         }
 
         lock.withLock {

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
@@ -26,6 +26,14 @@ public struct ModeTransitionError: Error, LocalizedError {
     }
 }
 
+private struct ModeTransitionRollbackError: Error, LocalizedError {
+    let failures: [String]
+
+    var errorDescription: String? {
+        failures.joined(separator: " ")
+    }
+}
+
 public enum MirroredCredentialSyncState: Sendable, Equatable {
     case local
     case synchronizable
@@ -254,14 +262,46 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     }
 
     private func rollbackModeTransition(context: ModeTransitionContext) async throws {
+        var failures: [String] = []
+
         for (connectionID, credential) in context.credentialsToMove {
-            try? await context.sourcePrimary.store(credential, for: connectionID)
-            try? context.sourceSharedStore.store(credential, for: connectionID)
+            do {
+                try await context.sourcePrimary.store(credential, for: connectionID)
+            } catch {
+                failures.append(
+                    "rollbackModeTransition sourcePrimary.store failed for \(connectionID.uuidString): \(error.localizedDescription)"
+                )
+            }
+
+            do {
+                try context.sourceSharedStore.store(credential, for: connectionID)
+            } catch {
+                failures.append(
+                    "rollbackModeTransition sourceSharedStore.store failed for \(connectionID.uuidString): \(error.localizedDescription)"
+                )
+            }
         }
 
         for connectionID in context.connectionIDs {
-            try? await context.targetPrimary.delete(for: connectionID)
-            try? context.targetSharedStore.delete(for: connectionID)
+            do {
+                try await context.targetPrimary.delete(for: connectionID)
+            } catch {
+                failures.append(
+                    "rollbackModeTransition targetPrimary.delete failed for \(connectionID.uuidString): \(error.localizedDescription)"
+                )
+            }
+
+            do {
+                try context.targetSharedStore.delete(for: connectionID)
+            } catch {
+                failures.append(
+                    "rollbackModeTransition targetSharedStore.delete failed for \(connectionID.uuidString): \(error.localizedDescription)"
+                )
+            }
+        }
+
+        if !failures.isEmpty {
+            throw ModeTransitionRollbackError(failures: failures)
         }
     }
 

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
@@ -20,6 +20,14 @@ public enum MirroredCredentialSyncState: Sendable, Equatable {
 /// Uses Keychain as the app-facing credential store while mirroring credentials
 /// into the shared credential store used by the File Provider extension.
 public final class MirroredCredentialProvider: CredentialProvider, @unchecked Sendable {
+    private struct ModeTransitionContext {
+        let credentialsToMove: [UUID: Credential]
+        let sourcePrimary: CredentialProvider
+        let sourceSharedStore: SharedCredentialStore
+        let targetPrimary: KeychainService
+        let targetSharedStore: SharedCredentialStore
+        let connectionIDs: [UUID]
+    }
 
     private let lock = NSLock()
     private let primaryFactory: @Sendable (KeychainItemSyncMode) -> KeychainService
@@ -150,14 +158,14 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
                 try targetSharedStore.store(credential, for: connectionID)
             }
         } catch {
-            try? await rollbackModeTransition(
+            try? await rollbackModeTransition(context: ModeTransitionContext(
                 credentialsToMove: credentialsToMove,
                 sourcePrimary: sourcePrimary,
                 sourceSharedStore: sourceSharedStore,
                 targetPrimary: targetPrimary,
                 targetSharedStore: targetSharedStore,
                 connectionIDs: connectionIDs
-            )
+            ))
             throw error
         }
 
@@ -189,22 +197,15 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
         }
     }
 
-    private func rollbackModeTransition(
-        credentialsToMove: [UUID: Credential],
-        sourcePrimary: CredentialProvider,
-        sourceSharedStore: SharedCredentialStore,
-        targetPrimary: KeychainService,
-        targetSharedStore: SharedCredentialStore,
-        connectionIDs: [UUID]
-    ) async throws {
-        for (connectionID, credential) in credentialsToMove {
-            try? await sourcePrimary.store(credential, for: connectionID)
-            try? sourceSharedStore.store(credential, for: connectionID)
+    private func rollbackModeTransition(context: ModeTransitionContext) async throws {
+        for (connectionID, credential) in context.credentialsToMove {
+            try? await context.sourcePrimary.store(credential, for: connectionID)
+            try? context.sourceSharedStore.store(credential, for: connectionID)
         }
 
-        for connectionID in connectionIDs {
-            try? await targetPrimary.delete(for: connectionID)
-            try? targetSharedStore.delete(for: connectionID)
+        for connectionID in context.connectionIDs {
+            try? await context.targetPrimary.delete(for: connectionID)
+            try? context.targetSharedStore.delete(for: connectionID)
         }
     }
 

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
@@ -32,7 +32,9 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     private let lock = NSLock()
     private let primaryFactory: @Sendable (KeychainItemSyncMode) -> KeychainService
     private let sharedStoreFactory: @Sendable (KeychainItemSyncMode) -> SharedCredentialStore
-    private let credentialExistenceProbe: @Sendable (KeychainItemSyncMode, UUID) async throws -> Bool
+    private let customCredentialExistenceProbe: (@Sendable (KeychainItemSyncMode, UUID) async throws -> Bool)?
+    private var primaryStoreCache: [KeychainItemSyncMode: KeychainService] = [:]
+    private var sharedStoreCache: [KeychainItemSyncMode: SharedCredentialStore] = [:]
     private var primary: CredentialProvider
     public private(set) var sharedStore: SharedCredentialStore
 
@@ -49,19 +51,7 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     ) {
         self.primaryFactory = primaryFactory
         self.sharedStoreFactory = sharedStoreFactory
-        if let credentialExistenceProbe {
-            self.credentialExistenceProbe = credentialExistenceProbe
-        } else {
-            self.credentialExistenceProbe = { mode, connectionID in
-                let primary = primaryFactory(mode)
-                let sharedStore = sharedStoreFactory(mode)
-                if try await primary.credential(for: connectionID) != nil {
-                    return true
-                }
-
-                return try sharedStore.credential(for: connectionID) != nil
-            }
-        }
+        self.customCredentialExistenceProbe = credentialExistenceProbe
         self.primary = primary
         self.sharedStore = sharedStore
     }
@@ -108,11 +98,11 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
         var foundSynchronizableCredential = false
 
         for connectionID in connectionIDs {
-            if try await credentialExistenceProbe(.local, connectionID) {
+            if try await credentialExists(in: .local, for: connectionID) {
                 foundLocalCredential = true
             }
 
-            if try await credentialExistenceProbe(.synchronizable, connectionID) {
+            if try await credentialExists(in: .synchronizable, for: connectionID) {
                 foundSynchronizableCredential = true
             }
 
@@ -212,6 +202,45 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     private func storesSnapshot() -> (CredentialProvider, SharedCredentialStore) {
         lock.withLock {
             (primary, sharedStore)
+        }
+    }
+
+    private func credentialExists(in mode: KeychainItemSyncMode, for connectionID: UUID) async throws -> Bool {
+        if let customCredentialExistenceProbe {
+            return try await customCredentialExistenceProbe(mode, connectionID)
+        }
+
+        let (primary, sharedStore) = cachedStores(for: mode)
+        if try await primary.credential(for: connectionID) != nil {
+            return true
+        }
+
+        return try sharedStore.credential(for: connectionID) != nil
+    }
+
+    private func cachedStores(
+        for mode: KeychainItemSyncMode
+    ) -> (primary: KeychainService, sharedStore: SharedCredentialStore) {
+        lock.withLock {
+            let primary: KeychainService
+            if let cachedPrimary = primaryStoreCache[mode] {
+                primary = cachedPrimary
+            } else {
+                let createdPrimary = primaryFactory(mode)
+                primaryStoreCache[mode] = createdPrimary
+                primary = createdPrimary
+            }
+
+            let sharedStore: SharedCredentialStore
+            if let cachedSharedStore = sharedStoreCache[mode] {
+                sharedStore = cachedSharedStore
+            } else {
+                let createdSharedStore = sharedStoreFactory(mode)
+                sharedStoreCache[mode] = createdSharedStore
+                sharedStore = createdSharedStore
+            }
+
+            return (primary, sharedStore)
         }
     }
 }

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
@@ -11,6 +11,21 @@ public enum MirroredCredentialProviderError: Error, LocalizedError {
     }
 }
 
+public struct ModeTransitionError: Error, LocalizedError {
+    public let originalError: Error
+    public let rollbackError: Error
+
+    public init(originalError: Error, rollbackError: Error) {
+        self.originalError = originalError
+        self.rollbackError = rollbackError
+    }
+
+    public var errorDescription: String? {
+        "Credential mode transition failed: \(originalError.localizedDescription). " +
+        "Rollback failed: \(rollbackError.localizedDescription)"
+    }
+}
+
 public enum MirroredCredentialSyncState: Sendable, Equatable {
     case local
     case synchronizable
@@ -187,15 +202,26 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
                     try targetSharedStore.store(credential, for: connectionID)
                 }
             } catch {
-                try? await rollbackModeTransition(context: ModeTransitionContext(
+                let originalError = error
+                let context = ModeTransitionContext(
                     credentialsToMove: credentialsToMove,
                     sourcePrimary: sourcePrimary,
                     sourceSharedStore: sourceSharedStore,
                     targetPrimary: targetPrimary,
                     targetSharedStore: targetSharedStore,
                     connectionIDs: connectionIDs
-                ))
-                throw error
+                )
+
+                do {
+                    try await rollbackModeTransition(context: context)
+                } catch {
+                    throw ModeTransitionError(
+                        originalError: originalError,
+                        rollbackError: error
+                    )
+                }
+
+                throw originalError
             }
 
             for connectionID in connectionIDs {

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/MirroredCredentialProvider.swift
@@ -1,21 +1,44 @@
 import Foundation
 
+public enum MirroredCredentialProviderError: Error, LocalizedError {
+    case unsupportedPrimaryProvider
+
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedPrimaryProvider:
+            return "The current credential provider does not support iCloud Keychain migration."
+        }
+    }
+}
+
 /// Uses Keychain as the app-facing credential store while mirroring credentials
 /// into the shared credential store used by the File Provider extension.
 public final class MirroredCredentialProvider: CredentialProvider, @unchecked Sendable {
 
-    private let primary: CredentialProvider
-    public let sharedStore: SharedCredentialStore
+    private let lock = NSLock()
+    private let primaryFactory: @Sendable (KeychainItemSyncMode) -> KeychainService
+    private let sharedStoreFactory: @Sendable (KeychainItemSyncMode) -> SharedCredentialStore
+    private var primary: CredentialProvider
+    public private(set) var sharedStore: SharedCredentialStore
 
     public init(
-        primary: CredentialProvider,
+        primary: CredentialProvider = KeychainService(),
         sharedStore: SharedCredentialStore = SharedCredentialStore(allowLegacyKeychainMigration: true)
     ) {
+        self.primaryFactory = { KeychainService(syncMode: $0) }
+        self.sharedStoreFactory = { SharedCredentialStore(syncMode: $0, allowLegacyKeychainMigration: true) }
         self.primary = primary
         self.sharedStore = sharedStore
     }
 
+    public var syncMode: KeychainItemSyncMode {
+        lock.withLock {
+            (primary as? KeychainService)?.syncMode ?? .local
+        }
+    }
+
     public func credential(for connectionID: UUID) async throws -> Credential? {
+        let (primary, sharedStore) = storesSnapshot()
         let primaryCredential = try await primary.credential(for: connectionID)
         if let primaryCredential {
             do {
@@ -30,12 +53,87 @@ public final class MirroredCredentialProvider: CredentialProvider, @unchecked Se
     }
 
     public func store(_ credential: Credential, for connectionID: UUID) async throws {
+        let (primary, sharedStore) = storesSnapshot()
         try await primary.store(credential, for: connectionID)
         try sharedStore.store(credential, for: connectionID)
     }
 
     public func delete(for connectionID: UUID) async throws {
+        let (primary, sharedStore) = storesSnapshot()
         try await primary.delete(for: connectionID)
         try sharedStore.delete(for: connectionID)
+    }
+
+    public func setSynchronizableEnabled(_ enabled: Bool, connectionIDs: [UUID]) async throws {
+        let targetMode: KeychainItemSyncMode = enabled ? .synchronizable : .local
+        let (sourcePrimary, sourceSharedStore) = storesSnapshot()
+        guard let keychainPrimary = sourcePrimary as? KeychainService else {
+            throw MirroredCredentialProviderError.unsupportedPrimaryProvider
+        }
+        guard keychainPrimary.syncMode != targetMode else {
+            return
+        }
+
+        let targetPrimary = primaryFactory(targetMode)
+        let targetSharedStore = sharedStoreFactory(targetMode)
+
+        var credentialsToMove: [UUID: Credential] = [:]
+        for connectionID in connectionIDs {
+            if let credential = try await credential(for: connectionID) {
+                credentialsToMove[connectionID] = credential
+            }
+        }
+
+        do {
+            for (connectionID, credential) in credentialsToMove {
+                try await targetPrimary.store(credential, for: connectionID)
+                try targetSharedStore.store(credential, for: connectionID)
+            }
+
+            for connectionID in connectionIDs {
+                try await sourcePrimary.delete(for: connectionID)
+                try sourceSharedStore.delete(for: connectionID)
+            }
+        } catch {
+            try? await rollbackModeTransition(
+                credentialsToMove: credentialsToMove,
+                sourcePrimary: sourcePrimary,
+                sourceSharedStore: sourceSharedStore,
+                targetPrimary: targetPrimary,
+                targetSharedStore: targetSharedStore,
+                connectionIDs: connectionIDs
+            )
+            throw error
+        }
+
+        lock.withLock {
+            primary = targetPrimary
+            sharedStore = targetSharedStore
+        }
+    }
+
+    private func rollbackModeTransition(
+        credentialsToMove: [UUID: Credential],
+        sourcePrimary: CredentialProvider,
+        sourceSharedStore: SharedCredentialStore,
+        targetPrimary: KeychainService,
+        targetSharedStore: SharedCredentialStore,
+        connectionIDs: [UUID]
+    ) async throws {
+        for (connectionID, credential) in credentialsToMove {
+            try? await sourcePrimary.store(credential, for: connectionID)
+            try? sourceSharedStore.store(credential, for: connectionID)
+        }
+
+        for connectionID in connectionIDs {
+            try? await targetPrimary.delete(for: connectionID)
+            try? targetSharedStore.delete(for: connectionID)
+        }
+    }
+
+    private func storesSnapshot() -> (CredentialProvider, SharedCredentialStore) {
+        lock.withLock {
+            (primary, sharedStore)
+        }
     }
 }

--- a/Packages/MFuseCore/Sources/MFuseCore/Shared/AppGroupConstants.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Shared/AppGroupConstants.swift
@@ -13,6 +13,9 @@ public enum AppGroupConstants {
     /// Key for marking File Provider extension onboarding as completed.
     public static let extensionOnboardedKey = "extensionOnboarded"
 
+    /// Key for persisting whether iCloud sync is enabled.
+    public static let iCloudSyncEnabledKey = "iCloudSyncEnabled"
+
     /// Shared container directory name for databases.
     public static let databasesDir = "Databases"
 
@@ -21,6 +24,9 @@ public enum AppGroupConstants {
 
     /// Filename for the sync anchor store database.
     public static let syncAnchorDB = "sync_anchors.sqlite"
+
+    /// The iCloud ubiquity container used by the main app.
+    public static let ubiquityContainerIdentifier = "iCloud.com.lollipopkit.mfuse"
 
     /// Keychain access group shared between the app and the File Provider extension.
     public static var keychainAccessGroup: String? {

--- a/Packages/MFuseCore/Sources/MFuseCore/Shared/SharedAppSettings.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Shared/SharedAppSettings.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public enum SharedAppSettings {
+    private static let defaults = UserDefaults(suiteName: AppGroupConstants.groupIdentifier)
+
+    public static var iCloudSyncEnabled: Bool {
+        defaults?.bool(forKey: AppGroupConstants.iCloudSyncEnabledKey) ?? false
+    }
+
+    public static func setICloudSyncEnabled(_ enabled: Bool) {
+        defaults?.set(enabled, forKey: AppGroupConstants.iCloudSyncEnabledKey)
+    }
+}

--- a/Packages/MFuseCore/Sources/MFuseCore/Shared/SharedCredentialStore.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Shared/SharedCredentialStore.swift
@@ -17,6 +17,7 @@ public final class SharedCredentialStore: @unchecked Sendable {
     private let accessGroup: String?
     private let allowLegacyKeychainMigration: Bool
     private let legacyAccessGroups: [String]
+    public let syncMode: KeychainItemSyncMode
     private var usesDataProtectionKeychain: Bool { accessGroup != nil }
 
     public init(
@@ -25,6 +26,7 @@ public final class SharedCredentialStore: @unchecked Sendable {
             forSecurityApplicationGroupIdentifier: AppGroupConstants.groupIdentifier
         ),
         accessGroup: String? = AppGroupConstants.keychainAccessGroup,
+        syncMode: KeychainItemSyncMode = SharedAppSettings.iCloudSyncEnabled ? .synchronizable : .local,
         allowLegacyKeychainMigration: Bool = true,
         legacyAccessGroups: [String] = [AppGroupConstants.legacyKeychainAccessGroup].compactMap { $0 }
     ) {
@@ -40,6 +42,7 @@ public final class SharedCredentialStore: @unchecked Sendable {
             )
         }
         self.accessGroup = accessGroup
+        self.syncMode = syncMode
         self.allowLegacyKeychainMigration = allowLegacyKeychainMigration
         self.legacyAccessGroups = legacyAccessGroups.filter { $0 != accessGroup }
     }
@@ -324,6 +327,9 @@ public final class SharedCredentialStore: @unchecked Sendable {
         }
         if useDataProtectionKeychain {
             query[kSecUseDataProtectionKeychain as String] = true
+        }
+        if syncMode == .synchronizable {
+            query[kSecAttrSynchronizable as String] = kCFBooleanTrue
         }
         return query
     }

--- a/Packages/MFuseCore/Sources/MFuseCore/Shared/SharedStorage.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Shared/SharedStorage.swift
@@ -61,18 +61,23 @@ public final class SharedStorage: Sendable {
 
     // MARK: - Connections
 
-    public func loadConnections() -> [ConnectionConfig] {
-        let connectionsFileExists = FileManager.default.fileExists(atPath: connectionsFileURL.path)
-        if let connections = readConnectionsFromDisk(at: connectionsFileURL) {
+    public func loadConnections() throws -> [ConnectionConfig] {
+        if let connections = try readConnectionsFromDisk(at: connectionsFileURL) {
             return connections
         }
-        guard !connectionsFileExists else {
+
+        guard let data = legacyDefaults?.data(forKey: AppGroupConstants.connectionsKey) else {
             return []
         }
 
-        guard let data = legacyDefaults?.data(forKey: AppGroupConstants.connectionsKey),
-              let connections = try? JSONDecoder().decode([ConnectionConfig].self, from: data) else {
-            return []
+        let connections: [ConnectionConfig]
+        do {
+            connections = try JSONDecoder().decode([ConnectionConfig].self, from: data)
+        } catch {
+            Self.logger.error(
+                "Failed to decode legacy connections from UserDefaults: \(String(describing: error), privacy: .public)"
+            )
+            throw error
         }
 
         try? persistConnections(connections)
@@ -85,7 +90,14 @@ public final class SharedStorage: Sendable {
 
     /// Find a single connection by its domain identifier.
     public func connection(forDomain domainID: String) -> ConnectionConfig? {
-        loadConnections().first { $0.domainIdentifier == domainID }
+        do {
+            return try loadConnections().first { $0.domainIdentifier == domainID }
+        } catch {
+            Self.logger.error(
+                "Failed to load connections for domain lookup \(domainID, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+            return nil
+        }
     }
 
     // MARK: - Database Paths
@@ -172,7 +184,11 @@ public final class SharedStorage: Sendable {
         }
     }
 
-    private func readConnectionsFromDisk(at url: URL) -> [ConnectionConfig]? {
+    private func readConnectionsFromDisk(at url: URL) throws -> [ConnectionConfig]? {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+
         var coordinationError: NSError?
         var readError: Error?
         var connections: [ConnectionConfig]?
@@ -190,23 +206,21 @@ public final class SharedStorage: Sendable {
             Self.logger.error(
                 "Failed to coordinate reading connections from \(url.path, privacy: .public): \(String(describing: coordinationError), privacy: .public)"
             )
-            return nil
+            throw coordinationError
         }
 
         if let readError {
             Self.logger.error(
                 "Failed to read connections from \(url.path, privacy: .public): \(String(describing: readError), privacy: .public)"
             )
-            return nil
+            throw readError
         }
 
         return connections
     }
 
-    private func decodeConnectionsFromDisk(at url: URL) throws -> [ConnectionConfig]? {
-        guard let data = try? Data(contentsOf: url) else {
-            return nil
-        }
+    private func decodeConnectionsFromDisk(at url: URL) throws -> [ConnectionConfig] {
+        let data = try Data(contentsOf: url)
         return try JSONDecoder().decode([ConnectionConfig].self, from: data)
     }
 }

--- a/Packages/MFuseCore/Sources/MFuseCore/Sync/ICloudConnectionSyncService.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Sync/ICloudConnectionSyncService.swift
@@ -1,0 +1,393 @@
+import Foundation
+import os.log
+
+public struct ICloudSyncAvailability: Sendable, Equatable {
+    public let isDriveAvailable: Bool
+    public let isKeychainAvailable: Bool
+    public let unavailableReasons: [String]
+
+    public var canEnableSync: Bool {
+        isDriveAvailable && isKeychainAvailable
+    }
+
+    public init(
+        isDriveAvailable: Bool,
+        isKeychainAvailable: Bool,
+        unavailableReasons: [String]
+    ) {
+        self.isDriveAvailable = isDriveAvailable
+        self.isKeychainAvailable = isKeychainAvailable
+        self.unavailableReasons = unavailableReasons
+    }
+}
+
+public struct ICloudConnectionRecord: Codable, Equatable, Sendable {
+    public let id: UUID
+    public var config: ConnectionConfig?
+    public var updatedAt: Date
+    public var deletedAt: Date?
+
+    public init(
+        id: UUID,
+        config: ConnectionConfig?,
+        updatedAt: Date,
+        deletedAt: Date? = nil
+    ) {
+        self.id = id
+        self.config = config
+        self.updatedAt = updatedAt
+        self.deletedAt = deletedAt
+    }
+
+    var eventDate: Date {
+        deletedAt ?? updatedAt
+    }
+}
+
+public struct ICloudConnectionRecordSet: Codable, Equatable, Sendable {
+    public var schemaVersion: Int
+    public var records: [ICloudConnectionRecord]
+
+    public init(schemaVersion: Int = 1, records: [ICloudConnectionRecord]) {
+        self.schemaVersion = schemaVersion
+        self.records = records
+    }
+}
+
+public struct ICloudConnectionSyncResult: Sendable, Equatable {
+    public let records: ICloudConnectionRecordSet
+    public let liveConnections: [ConnectionConfig]
+    public let didUpdateLocalSnapshot: Bool
+}
+
+public actor ICloudConnectionSyncService {
+    private static let logger = Logger(
+        subsystem: "com.lollipopkit.mfuse",
+        category: "ICloudConnectionSyncService"
+    )
+
+    private let storage: SharedStorage
+    private let fileManager: FileManager
+    private let ubiquityContainerURLProvider: @Sendable () -> URL?
+    private let keychainAvailabilityProbe: @Sendable () -> Bool
+    private let now: @Sendable () -> Date
+    private let connectionSaver: @Sendable ([ConnectionConfig]) throws -> Void
+
+    public init(
+        storage: SharedStorage,
+        fileManager: FileManager = .default,
+        ubiquityContainerURLProvider: @escaping @Sendable () -> URL? = {
+            FileManager.default.url(
+                forUbiquityContainerIdentifier: AppGroupConstants.ubiquityContainerIdentifier
+            )
+        },
+        keychainAvailabilityProbe: @escaping @Sendable () -> Bool = {
+            KeychainService.isSynchronizableKeychainAvailable()
+        },
+        now: @escaping @Sendable () -> Date = { Date() },
+        connectionSaver: (@Sendable ([ConnectionConfig]) throws -> Void)? = nil
+    ) {
+        self.storage = storage
+        self.fileManager = fileManager
+        self.ubiquityContainerURLProvider = ubiquityContainerURLProvider
+        self.keychainAvailabilityProbe = keychainAvailabilityProbe
+        self.now = now
+        self.connectionSaver = connectionSaver ?? { connections in
+            try storage.saveConnections(connections)
+        }
+    }
+
+    public func availability() -> ICloudSyncAvailability {
+        let hasDrive = ubiquityContainerURLProvider() != nil
+        let hasKeychain = keychainAvailabilityProbe()
+        var reasons: [String] = []
+
+        if !hasDrive {
+            reasons.append("iCloud Drive is unavailable for MFuse.")
+        }
+        if !hasKeychain {
+            reasons.append("iCloud Keychain is unavailable for MFuse.")
+        }
+
+        return ICloudSyncAvailability(
+            isDriveAvailable: hasDrive,
+            isKeychainAvailable: hasKeychain,
+            unavailableReasons: reasons
+        )
+    }
+
+    public func synchronize() throws -> ICloudConnectionSyncResult {
+        guard let cloudRootURL = ubiquityContainerURLProvider() else {
+            throw NSError(
+                domain: "ICloudConnectionSyncService",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "iCloud Drive is unavailable for MFuse."]
+            )
+        }
+
+        let localConnections = storage.loadConnections()
+        let localRecords = try readRecordSet(at: localStateFileURL)
+        let cloudRecords = try readRecordSet(at: cloudRecordsFileURL(in: cloudRootURL))
+        let materializedLocalRecords = materializeLocalRecordSet(
+            liveConnections: localConnections,
+            base: localRecords
+        )
+        let mergedRecordSet = merge(local: materializedLocalRecords, cloud: cloudRecords)
+        let mergedConnections = liveConnections(from: mergedRecordSet)
+        let didUpdateLocalSnapshot = mergedConnections != localConnections
+        let cloudURL = cloudRecordsFileURL(in: cloudRootURL)
+
+        do {
+            try writeRecordSet(mergedRecordSet, to: cloudURL)
+            try writeRecordSet(mergedRecordSet, to: localStateFileURL)
+            if didUpdateLocalSnapshot {
+                try connectionSaver(mergedConnections)
+            }
+        } catch {
+            rollbackRecordSet(
+                cloudRecords,
+                at: cloudURL,
+                description: "cloud iCloud connection records"
+            )
+            rollbackRecordSet(
+                localRecords,
+                at: localStateFileURL,
+                description: "local iCloud connection state"
+            )
+            throw error
+        }
+
+        return ICloudConnectionSyncResult(
+            records: mergedRecordSet,
+            liveConnections: mergedConnections,
+            didUpdateLocalSnapshot: didUpdateLocalSnapshot
+        )
+    }
+
+    public func markCurrentStateAsBaseline() throws {
+        let snapshot = ICloudConnectionRecordSet(
+            records: storage.loadConnections().map {
+                ICloudConnectionRecord(id: $0.id, config: $0, updatedAt: now())
+            }
+        )
+        try writeRecordSet(snapshot, to: localStateFileURL)
+    }
+
+    public func merge(
+        local: ICloudConnectionRecordSet,
+        cloud: ICloudConnectionRecordSet?
+    ) -> ICloudConnectionRecordSet {
+        var mergedByID: [UUID: ICloudConnectionRecord] = [:]
+        for record in local.records {
+            mergedByID[record.id] = record
+        }
+
+        for record in cloud?.records ?? [] {
+            guard let existing = mergedByID[record.id] else {
+                mergedByID[record.id] = record
+                continue
+            }
+            if record.eventDate >= existing.eventDate {
+                mergedByID[record.id] = record
+            }
+        }
+
+        let records = mergedByID.values.sorted { lhs, rhs in
+            if lhs.eventDate == rhs.eventDate {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.eventDate < rhs.eventDate
+        }
+        return ICloudConnectionRecordSet(records: records)
+    }
+
+    private var localStateFileURL: URL {
+        storage.containerURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("MFuse", isDirectory: true)
+            .appendingPathComponent("iCloud", isDirectory: true)
+            .appendingPathComponent("connections-sync-state.json")
+    }
+
+    private func cloudRecordsFileURL(in cloudRootURL: URL) -> URL {
+        cloudRootURL
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("MFuse", isDirectory: true)
+            .appendingPathComponent("connections-records.json")
+    }
+
+    private func materializeLocalRecordSet(
+        liveConnections: [ConnectionConfig],
+        base: ICloudConnectionRecordSet?
+    ) -> ICloudConnectionRecordSet {
+        let liveByID = Dictionary(uniqueKeysWithValues: liveConnections.map { ($0.id, $0) })
+        var recordsByID = Dictionary(
+            uniqueKeysWithValues: (base?.records ?? []).map { ($0.id, $0) }
+        )
+        let timestamp = now()
+
+        for (id, config) in liveByID {
+            if let existing = recordsByID[id] {
+                if existing.deletedAt != nil || existing.config != config {
+                    recordsByID[id] = ICloudConnectionRecord(
+                        id: id,
+                        config: config,
+                        updatedAt: timestamp,
+                        deletedAt: nil
+                    )
+                } else {
+                    recordsByID[id] = existing
+                }
+            } else {
+                recordsByID[id] = ICloudConnectionRecord(
+                    id: id,
+                    config: config,
+                    updatedAt: timestamp,
+                    deletedAt: nil
+                )
+            }
+        }
+
+        for (id, existing) in recordsByID where liveByID[id] == nil && existing.deletedAt == nil {
+            recordsByID[id] = ICloudConnectionRecord(
+                id: id,
+                config: existing.config,
+                updatedAt: existing.updatedAt,
+                deletedAt: timestamp
+            )
+        }
+
+        let records = recordsByID.values.sorted { lhs, rhs in
+            if lhs.eventDate == rhs.eventDate {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.eventDate < rhs.eventDate
+        }
+        return ICloudConnectionRecordSet(records: records)
+    }
+
+    private func liveConnections(from recordSet: ICloudConnectionRecordSet) -> [ConnectionConfig] {
+        recordSet.records.compactMap { record in
+            guard record.deletedAt == nil else {
+                return nil
+            }
+            return record.config
+        }
+    }
+
+    private func readRecordSet(at url: URL) throws -> ICloudConnectionRecordSet? {
+        var coordinationError: NSError?
+        var readError: Error?
+        var recordSet: ICloudConnectionRecordSet?
+        let coordinator = NSFileCoordinator()
+        coordinator.coordinate(readingItemAt: url, options: [], error: &coordinationError) { coordinatedURL in
+            do {
+                let data = try Data(contentsOf: coordinatedURL)
+                recordSet = try JSONDecoder().decode(ICloudConnectionRecordSet.self, from: data)
+            } catch {
+                let nsError = error as NSError
+                if nsError.domain == NSCocoaErrorDomain,
+                   nsError.code == NSFileReadNoSuchFileError {
+                    recordSet = nil
+                    return
+                }
+                readError = error
+            }
+        }
+
+        if let coordinationError {
+            Self.logger.error(
+                "Failed to coordinate reading iCloud records from \(url.path, privacy: .public): \(String(describing: coordinationError), privacy: .public)"
+            )
+            throw coordinationError
+        }
+        if let readError {
+            Self.logger.error(
+                "Failed to read iCloud records from \(url.path, privacy: .public): \(String(describing: readError), privacy: .public)"
+            )
+            throw readError
+        }
+        return recordSet
+    }
+
+    private func writeRecordSet(_ recordSet: ICloudConnectionRecordSet, to url: URL) throws {
+        try fileManager.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        var coordinationError: NSError?
+        var writeError: Error?
+        let coordinator = NSFileCoordinator()
+        coordinator.coordinate(writingItemAt: url, options: .forReplacing, error: &coordinationError) { coordinatedURL in
+            do {
+                let data = try JSONEncoder().encode(recordSet)
+                try data.write(to: coordinatedURL, options: .atomic)
+            } catch {
+                writeError = error
+            }
+        }
+
+        if let coordinationError {
+            Self.logger.error(
+                "Failed to coordinate writing iCloud records to \(url.path, privacy: .public): \(String(describing: coordinationError), privacy: .public)"
+            )
+            throw coordinationError
+        }
+        if let writeError {
+            Self.logger.error(
+                "Failed to write iCloud records to \(url.path, privacy: .public): \(String(describing: writeError), privacy: .public)"
+            )
+            throw writeError
+        }
+    }
+
+    private func rollbackRecordSet(
+        _ previousRecordSet: ICloudConnectionRecordSet?,
+        at url: URL,
+        description: String
+    ) {
+        do {
+            if let previousRecordSet {
+                try writeRecordSet(previousRecordSet, to: url)
+            } else {
+                try deleteRecordSet(at: url)
+            }
+        } catch {
+            Self.logger.error(
+                "Failed to rollback \(description, privacy: .public) at \(url.path, privacy: .public): \(String(describing: error), privacy: .public)"
+            )
+        }
+    }
+
+    private func deleteRecordSet(at url: URL) throws {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return
+        }
+
+        var coordinationError: NSError?
+        var deleteError: Error?
+        let coordinator = NSFileCoordinator()
+        coordinator.coordinate(writingItemAt: url, options: .forDeleting, error: &coordinationError) { coordinatedURL in
+            do {
+                try fileManager.removeItem(at: coordinatedURL)
+            } catch {
+                deleteError = error
+            }
+        }
+
+        if let coordinationError {
+            Self.logger.error(
+                "Failed to coordinate deleting iCloud records at \(url.path, privacy: .public): \(String(describing: coordinationError), privacy: .public)"
+            )
+            throw coordinationError
+        }
+        if let deleteError {
+            Self.logger.error(
+                "Failed to delete iCloud records at \(url.path, privacy: .public): \(String(describing: deleteError), privacy: .public)"
+            )
+            throw deleteError
+        }
+    }
+}

--- a/Packages/MFuseCore/Sources/MFuseCore/Sync/ICloudConnectionSyncService.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Sync/ICloudConnectionSyncService.swift
@@ -1,6 +1,17 @@
 import Foundation
 import os.log
 
+private enum ICloudConnectionRecordValidationError: Error, LocalizedError {
+    case missingConfigForLiveRecord(UUID)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingConfigForLiveRecord(let id):
+            return "iCloud connection record \(id.uuidString) is missing config for a live entry."
+        }
+    }
+}
+
 public struct ICloudSyncAvailability: Sendable, Equatable {
     public let isDriveAvailable: Bool
     public let isKeychainAvailable: Bool
@@ -72,6 +83,7 @@ public actor ICloudConnectionSyncService {
     private let keychainAvailabilityProbe: @Sendable () -> Bool
     private let now: @Sendable () -> Date
     private let connectionSaver: @Sendable ([ConnectionConfig]) throws -> Void
+    private let beforeWritingAttempt: @Sendable () throws -> Void
 
     public init(
         storage: SharedStorage,
@@ -86,12 +98,39 @@ public actor ICloudConnectionSyncService {
         },
         now: @escaping @Sendable () -> Date = { Date() },
         connectionSaver: (@Sendable ([ConnectionConfig]) throws -> Void)? = nil
+        ) {
+        self.storage = storage
+        self.fileManager = fileManager
+        self.ubiquityContainerURLProvider = ubiquityContainerURLProvider
+        self.keychainAvailabilityProbe = keychainAvailabilityProbe
+        self.now = now
+        self.beforeWritingAttempt = {}
+        self.connectionSaver = connectionSaver ?? { connections in
+            try storage.saveConnections(connections)
+        }
+    }
+
+    init(
+        storage: SharedStorage,
+        fileManager: FileManager = .default,
+        ubiquityContainerURLProvider: @escaping @Sendable () -> URL? = {
+            FileManager.default.url(
+                forUbiquityContainerIdentifier: AppGroupConstants.ubiquityContainerIdentifier
+            )
+        },
+        keychainAvailabilityProbe: @escaping @Sendable () -> Bool = {
+            KeychainService.isSynchronizableKeychainAvailable()
+        },
+        now: @escaping @Sendable () -> Date = { Date() },
+        connectionSaver: (@Sendable ([ConnectionConfig]) throws -> Void)? = nil,
+        beforeWritingAttempt: @escaping @Sendable () throws -> Void
     ) {
         self.storage = storage
         self.fileManager = fileManager
         self.ubiquityContainerURLProvider = ubiquityContainerURLProvider
         self.keychainAvailabilityProbe = keychainAvailabilityProbe
         self.now = now
+        self.beforeWritingAttempt = beforeWritingAttempt
         self.connectionSaver = connectionSaver ?? { connections in
             try storage.saveConnections(connections)
         }
@@ -117,6 +156,14 @@ public actor ICloudConnectionSyncService {
     }
 
     public func synchronize() throws -> ICloudConnectionSyncResult {
+        guard SharedAppSettings.iCloudSyncEnabled else {
+            throw NSError(
+                domain: "ICloudConnectionSyncService",
+                code: 0,
+                userInfo: [NSLocalizedDescriptionKey: "iCloud Sync is disabled."]
+            )
+        }
+
         guard let cloudRootURL = ubiquityContainerURLProvider() else {
             throw NSError(
                 domain: "ICloudConnectionSyncService",
@@ -125,48 +172,80 @@ public actor ICloudConnectionSyncService {
             )
         }
 
-        let localConnections = storage.loadConnections()
-        let localRecords = try readRecordSet(at: localStateFileURL)
-        let cloudRecords = try readRecordSet(at: cloudRecordsFileURL(in: cloudRootURL))
-        let materializedLocalRecords = materializeLocalRecordSet(
-            liveConnections: localConnections,
-            base: localRecords
-        )
-        let mergedRecordSet = merge(local: materializedLocalRecords, cloud: cloudRecords)
-        let mergedConnections = liveConnections(from: mergedRecordSet)
-        let didUpdateLocalSnapshot = mergedConnections != localConnections
         let cloudURL = cloudRecordsFileURL(in: cloudRootURL)
+        let maxAttempts = 3
 
-        do {
-            try writeRecordSet(mergedRecordSet, to: cloudURL)
-            try writeRecordSet(mergedRecordSet, to: localStateFileURL)
-            if didUpdateLocalSnapshot {
-                try connectionSaver(mergedConnections)
+        for attempt in 1...maxAttempts {
+            let localConnections = try storage.loadConnections()
+            let localRecords = try readRecordSet(at: localStateFileURL)
+            let cloudRecords = try readRecordSet(at: cloudURL)
+            let materializedLocalRecords = materializeLocalRecordSet(
+                liveConnections: localConnections,
+                base: localRecords
+            )
+            let mergedRecordSet = merge(local: materializedLocalRecords, cloud: cloudRecords)
+            let mergedConnections = liveConnections(from: mergedRecordSet)
+            let didUpdateLocalSnapshot = mergedConnections != localConnections
+
+            try beforeWritingAttempt()
+
+            let currentLocalConnections = try storage.loadConnections()
+            let currentLocalRecords = try readRecordSet(at: localStateFileURL)
+            let currentCloudRecords = try readRecordSet(at: cloudURL)
+            guard currentLocalConnections == localConnections,
+                  currentLocalRecords == localRecords,
+                  currentCloudRecords == cloudRecords else {
+                if attempt < maxAttempts {
+                    continue
+                }
+                throw NSError(
+                    domain: "ICloudConnectionSyncService",
+                    code: 2,
+                    userInfo: [
+                        NSLocalizedDescriptionKey: "Local or cloud connection state changed during iCloud synchronization. Please retry."
+                    ]
+                )
             }
-        } catch {
-            rollbackRecordSet(
-                cloudRecords,
-                at: cloudURL,
-                description: "cloud iCloud connection records"
+
+            do {
+                try writeRecordSet(mergedRecordSet, to: cloudURL)
+                try writeRecordSet(mergedRecordSet, to: localStateFileURL)
+                if didUpdateLocalSnapshot {
+                    try connectionSaver(mergedConnections)
+                }
+            } catch {
+                rollbackRecordSet(
+                    currentCloudRecords,
+                    at: cloudURL,
+                    description: "cloud iCloud connection records"
+                )
+                rollbackRecordSet(
+                    currentLocalRecords,
+                    at: localStateFileURL,
+                    description: "local iCloud connection state"
+                )
+                throw error
+            }
+
+            return ICloudConnectionSyncResult(
+                records: mergedRecordSet,
+                liveConnections: mergedConnections,
+                didUpdateLocalSnapshot: didUpdateLocalSnapshot
             )
-            rollbackRecordSet(
-                localRecords,
-                at: localStateFileURL,
-                description: "local iCloud connection state"
-            )
-            throw error
         }
 
-        return ICloudConnectionSyncResult(
-            records: mergedRecordSet,
-            liveConnections: mergedConnections,
-            didUpdateLocalSnapshot: didUpdateLocalSnapshot
+        throw NSError(
+            domain: "ICloudConnectionSyncService",
+            code: 2,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Local or cloud connection state changed during iCloud synchronization. Please retry."
+            ]
         )
     }
 
     public func markCurrentStateAsBaseline() throws {
         let snapshot = ICloudConnectionRecordSet(
-            records: storage.loadConnections().map {
+            records: try storage.loadConnections().map {
                 ICloudConnectionRecord(id: $0.id, config: $0, updatedAt: now())
             }
         )
@@ -252,7 +331,7 @@ public actor ICloudConnectionSyncService {
         for (id, existing) in recordsByID where liveByID[id] == nil && existing.deletedAt == nil {
             recordsByID[id] = ICloudConnectionRecord(
                 id: id,
-                config: existing.config,
+                config: nil,
                 updatedAt: existing.updatedAt,
                 deletedAt: timestamp
             )
@@ -308,7 +387,16 @@ public actor ICloudConnectionSyncService {
             )
             throw readError
         }
+        if let recordSet {
+            try validate(recordSet: recordSet)
+        }
         return recordSet
+    }
+
+    private func validate(recordSet: ICloudConnectionRecordSet) throws {
+        for record in recordSet.records where record.deletedAt == nil && record.config == nil {
+            throw ICloudConnectionRecordValidationError.missingConfigForLiveRecord(record.id)
+        }
     }
 
     private func writeRecordSet(_ recordSet: ICloudConnectionRecordSet, to url: URL) throws {

--- a/Packages/MFuseCore/Sources/MFuseCore/Sync/ICloudConnectionSyncService.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Sync/ICloudConnectionSyncService.swift
@@ -266,6 +266,9 @@ public actor ICloudConnectionSyncService {
                 mergedByID[record.id] = record
                 continue
             }
+            // In mergedByID, `record.eventDate >= existing.eventDate` makes cloud win ties.
+            // When timestamps are equal, prefer the cloud record so sync converges to the
+            // latest shared snapshot instead of reasserting stale local state.
             if record.eventDate >= existing.eventDate {
                 mergedByID[record.id] = record
             }

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
@@ -330,7 +330,7 @@ final class ConnectionManagerTests: XCTestCase {
 
         XCTAssertEqual(manager.connections, [config])
         XCTAssertEqual(manager.state(for: config.id), .disconnected)
-        XCTAssertEqual(storage.loadConnections(), [config])
+        XCTAssertEqual(try storage.loadConnections(), [config])
         XCTAssertEqual(credentialProvider.credentials[config.id], Credential(password: "pass"))
         XCTAssertEqual(credentialProvider.deletedConnectionIDs, [config.id])
     }
@@ -355,7 +355,7 @@ final class ConnectionManagerTests: XCTestCase {
         }
 
         XCTAssertEqual(manager.connections, [config])
-        XCTAssertEqual(storage.loadConnections(), [config])
+        XCTAssertEqual(try storage.loadConnections(), [config])
         XCTAssertEqual(credentialProvider.credentials[config.id], credential)
         XCTAssertEqual(credentialProvider.deletedConnectionIDs, [config.id])
         XCTAssertEqual(credentialProvider.storedConnectionIDs, [config.id])
@@ -389,7 +389,7 @@ final class ConnectionManagerTests: XCTestCase {
         }
 
         XCTAssertEqual(manager.connections, [config])
-        XCTAssertEqual(storage.loadConnections(), [config])
+        XCTAssertEqual(try storage.loadConnections(), [config])
         XCTAssertNil(credentialProvider.credentials[config.id])
         XCTAssertEqual(credentialProvider.deletedConnectionIDs, [config.id])
         XCTAssertEqual(credentialProvider.storedConnectionIDs, [config.id])
@@ -459,7 +459,7 @@ final class ConnectionManagerTests: XCTestCase {
         XCTAssertNotNil(manager.fileSystem(for: config.id))
         XCTAssertEqual(credentialProvider.credentials[config.id], Credential(password: "pass"))
         XCTAssertTrue(credentialProvider.deletedConnectionIDs.isEmpty)
-        XCTAssertEqual(storage.loadConnections(), [config])
+        XCTAssertEqual(try storage.loadConnections(), [config])
     }
 
     func testRemoveConnectionAbortsWhenUnmountLeavesMountStateError() async throws {
@@ -502,7 +502,60 @@ final class ConnectionManagerTests: XCTestCase {
         XCTAssertNil(manager.fileSystem(for: config.id))
         XCTAssertEqual(credentialProvider.credentials[config.id], Credential(password: "pass"))
         XCTAssertTrue(credentialProvider.deletedConnectionIDs.isEmpty)
-        XCTAssertEqual(storage.loadConnections(), [config])
+        XCTAssertEqual(try storage.loadConnections(), [config])
+    }
+
+    func testReloadConnectionsFromStorageSkipsCleanupWhenReloadFails() async throws {
+        let config = ConnectionConfig(
+            name: "ReloadFailure",
+            backendType: .sftp,
+            host: "example.com",
+            username: "user"
+        )
+        credentialProvider.credentials[config.id] = Credential(password: "pass")
+        try manager.add(config)
+        await manager.connect(config.id)
+        guard let fileSystem = lastCreatedFileSystem else {
+            return XCTFail("Expected file system to be created")
+        }
+
+        try Data("not-json".utf8).write(to: storage.connectionsFileURL, options: .atomic)
+
+        await manager.reloadConnectionsFromStorage()
+
+        XCTAssertEqual(manager.connections, [config])
+        XCTAssertEqual(manager.state(for: config.id), .connected)
+        XCTAssertNotNil(manager.fileSystem(for: config.id))
+        let disconnectCalled = await fileSystem.disconnectCalled
+        XCTAssertFalse(disconnectCalled)
+    }
+
+    func testReloadConnectionsFromStoragePreservesRuntimeStateWhenDisconnectCleanupFails() async throws {
+        let config = ConnectionConfig(
+            name: "ReloadCleanupFailure",
+            backendType: .sftp,
+            host: "example.com",
+            username: "user"
+        )
+        credentialProvider.credentials[config.id] = Credential(password: "pass")
+        try manager.add(config)
+        await manager.connect(config.id)
+        guard let fileSystem = lastCreatedFileSystem else {
+            return XCTFail("Expected file system to be created")
+        }
+        await fileSystem.setDisconnectShouldFail(true)
+        try storage.saveConnections([])
+
+        await manager.reloadConnectionsFromStorage()
+
+        XCTAssertEqual(manager.connections, [config])
+        guard case .error(let message) = manager.state(for: config.id) else {
+            return XCTFail("Expected connection error state after failed cleanup during reload")
+        }
+        XCTAssertTrue(message.contains("mock disconnect failure"))
+        XCTAssertNotNil(manager.fileSystem(for: config.id))
+        let disconnectCalled = await fileSystem.disconnectCalled
+        XCTAssertTrue(disconnectCalled)
     }
 
     func testConnectSuccess() async throws {

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ICloudConnectionSyncServiceTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ICloudConnectionSyncServiceTests.swift
@@ -1,0 +1,260 @@
+import XCTest
+@testable import MFuseCore
+
+final class ICloudConnectionSyncServiceTests: XCTestCase {
+    private final class DateBox: @unchecked Sendable {
+        var value: Date
+
+        init(_ value: Date) {
+            self.value = value
+        }
+    }
+
+    private var containerURL: URL!
+    private var cloudRootURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        containerURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MFuseCoreICloudLocal-\(UUID().uuidString)", isDirectory: true)
+        cloudRootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MFuseCoreICloudCloud-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDown() {
+        if let containerURL {
+            try? FileManager.default.removeItem(at: containerURL)
+        }
+        if let cloudRootURL {
+            try? FileManager.default.removeItem(at: cloudRootURL)
+        }
+        super.tearDown()
+    }
+
+    func testSynchronizeMergesLocalAndCloudOnFirstEnable() async throws {
+        let storage = SharedStorage(containerURL: containerURL)
+        let dateBox = DateBox(Date(timeIntervalSince1970: 1_000))
+        let service = makeService(storage: storage, dateBox: dateBox)
+
+        let localConfig = ConnectionConfig(
+            name: "Local",
+            backendType: .sftp,
+            host: "local.example.com"
+        )
+        let cloudConfig = ConnectionConfig(
+            name: "Cloud",
+            backendType: .sftp,
+            host: "cloud.example.com"
+        )
+        try storage.saveConnections([localConfig])
+        try writeCloudRecordSet(
+            ICloudConnectionRecordSet(records: [
+                ICloudConnectionRecord(id: cloudConfig.id, config: cloudConfig, updatedAt: dateBox.value),
+            ])
+        )
+
+        let result = try await service.synchronize()
+
+        XCTAssertEqual(Set(result.liveConnections), Set([localConfig, cloudConfig]))
+        XCTAssertEqual(Set(storage.loadConnections()), Set([localConfig, cloudConfig]))
+    }
+
+    func testSynchronizePrefersNewerRecordForSameID() async throws {
+        let storage = SharedStorage(containerURL: containerURL)
+        let dateBox = DateBox(Date(timeIntervalSince1970: 1_000))
+        let service = makeService(storage: storage, dateBox: dateBox)
+
+        let connectionID = UUID()
+        let localConfig = ConnectionConfig(
+            id: connectionID,
+            name: "Local",
+            backendType: .sftp,
+            host: "example.com"
+        )
+        let cloudConfig = ConnectionConfig(
+            id: connectionID,
+            name: "Cloud Newer",
+            backendType: .sftp,
+            host: "example.com"
+        )
+
+        try storage.saveConnections([localConfig])
+        try await service.markCurrentStateAsBaseline()
+        dateBox.value = Date(timeIntervalSince1970: 2_000)
+        try writeCloudRecordSet(
+            ICloudConnectionRecordSet(records: [
+                ICloudConnectionRecord(id: connectionID, config: cloudConfig, updatedAt: dateBox.value),
+            ])
+        )
+
+        let result = try await service.synchronize()
+
+        XCTAssertEqual(result.liveConnections, [cloudConfig])
+        XCTAssertEqual(storage.loadConnections(), [cloudConfig])
+    }
+
+    func testSynchronizeWritesTombstoneSoDeletedConnectionDoesNotReappear() async throws {
+        let storage = SharedStorage(containerURL: containerURL)
+        let dateBox = DateBox(Date(timeIntervalSince1970: 1_000))
+        let service = makeService(storage: storage, dateBox: dateBox)
+
+        let config = ConnectionConfig(
+            name: "Deleted",
+            backendType: .sftp,
+            host: "deleted.example.com"
+        )
+
+        try storage.saveConnections([config])
+        try await service.markCurrentStateAsBaseline()
+
+        try writeCloudRecordSet(
+            ICloudConnectionRecordSet(records: [
+                ICloudConnectionRecord(id: config.id, config: config, updatedAt: dateBox.value),
+            ])
+        )
+
+        dateBox.value = Date(timeIntervalSince1970: 2_000)
+        try storage.saveConnections([])
+
+        let result = try await service.synchronize()
+        let cloudRecordSet = try XCTUnwrap(readCloudRecordSet())
+        let record = try XCTUnwrap(cloudRecordSet.records.first(where: { $0.id == config.id }))
+
+        XCTAssertTrue(result.liveConnections.isEmpty)
+        XCTAssertEqual(storage.loadConnections(), [])
+        XCTAssertEqual(record.deletedAt, dateBox.value)
+    }
+
+    func testSynchronizeKeepsDuplicateEndpointsWhenIDsDiffer() async throws {
+        let storage = SharedStorage(containerURL: containerURL)
+        let dateBox = DateBox(Date(timeIntervalSince1970: 1_000))
+        let service = makeService(storage: storage, dateBox: dateBox)
+
+        let localConfig = ConnectionConfig(
+            name: "Local",
+            backendType: .sftp,
+            host: "same.example.com",
+            username: "lk"
+        )
+        let cloudConfig = ConnectionConfig(
+            name: "Cloud",
+            backendType: .sftp,
+            host: "same.example.com",
+            username: "lk"
+        )
+
+        try storage.saveConnections([localConfig])
+        try writeCloudRecordSet(
+            ICloudConnectionRecordSet(records: [
+                ICloudConnectionRecord(id: cloudConfig.id, config: cloudConfig, updatedAt: dateBox.value),
+            ])
+        )
+
+        let result = try await service.synchronize()
+
+        XCTAssertEqual(result.liveConnections.count, 2)
+        XCTAssertEqual(Set(result.liveConnections.map(\.id)), Set([localConfig.id, cloudConfig.id]))
+    }
+
+    func testSynchronizeRollsBackCloudAndLocalStateWhenPersistingConnectionsFails() async throws {
+        let storage = SharedStorage(containerURL: containerURL)
+        let dateBox = DateBox(Date(timeIntervalSince1970: 1_000))
+        let localConfig = ConnectionConfig(
+            name: "Local",
+            backendType: .sftp,
+            host: "local.example.com"
+        )
+        let cloudConfig = ConnectionConfig(
+            name: "Cloud",
+            backendType: .sftp,
+            host: "cloud.example.com"
+        )
+
+        try storage.saveConnections([localConfig])
+        let baselineService = makeService(storage: storage, dateBox: dateBox)
+        try await baselineService.markCurrentStateAsBaseline()
+
+        let previousLocalState = try XCTUnwrap(readLocalStateRecordSet())
+        let previousCloudState = ICloudConnectionRecordSet(records: [
+            ICloudConnectionRecord(id: cloudConfig.id, config: cloudConfig, updatedAt: dateBox.value),
+        ])
+        try writeCloudRecordSet(previousCloudState)
+
+        let expectedError = NSError(domain: "ICloudConnectionSyncServiceTests", code: 99)
+        let failingService = ICloudConnectionSyncService(
+            storage: storage,
+            ubiquityContainerURLProvider: { [cloudRootURL] in cloudRootURL },
+            keychainAvailabilityProbe: { true },
+            now: { dateBox.value },
+            connectionSaver: { _ in
+                throw expectedError
+            }
+        )
+
+        do {
+            _ = try await failingService.synchronize()
+            XCTFail("Expected synchronize to fail when persisting merged connections fails")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, expectedError.domain)
+            XCTAssertEqual((error as NSError).code, expectedError.code)
+        }
+
+        XCTAssertEqual(try readCloudRecordSet(), previousCloudState)
+        XCTAssertEqual(try readLocalStateRecordSet(), previousLocalState)
+        XCTAssertEqual(storage.loadConnections(), [localConfig])
+    }
+
+    private func makeService(
+        storage: SharedStorage,
+        dateBox: DateBox
+    ) -> ICloudConnectionSyncService {
+        ICloudConnectionSyncService(
+            storage: storage,
+            ubiquityContainerURLProvider: { [cloudRootURL] in cloudRootURL },
+            keychainAvailabilityProbe: { true },
+            now: { dateBox.value }
+        )
+    }
+
+    private func writeCloudRecordSet(_ recordSet: ICloudConnectionRecordSet) throws {
+        let url = cloudRecordsURL()
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let data = try JSONEncoder().encode(recordSet)
+        try data.write(to: url, options: .atomic)
+    }
+
+    private func readCloudRecordSet() throws -> ICloudConnectionRecordSet? {
+        let url = cloudRecordsURL()
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+        return try JSONDecoder().decode(ICloudConnectionRecordSet.self, from: Data(contentsOf: url))
+    }
+
+    private func readLocalStateRecordSet() throws -> ICloudConnectionRecordSet? {
+        let url = localStateURL()
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return nil
+        }
+        return try JSONDecoder().decode(ICloudConnectionRecordSet.self, from: Data(contentsOf: url))
+    }
+
+    private func cloudRecordsURL() -> URL {
+        cloudRootURL
+            .appendingPathComponent("Documents", isDirectory: true)
+            .appendingPathComponent("MFuse", isDirectory: true)
+            .appendingPathComponent("connections-records.json")
+    }
+
+    private func localStateURL() -> URL {
+        containerURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent("MFuse", isDirectory: true)
+            .appendingPathComponent("iCloud", isDirectory: true)
+            .appendingPathComponent("connections-sync-state.json")
+    }
+}

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ICloudConnectionSyncServiceTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ICloudConnectionSyncServiceTests.swift
@@ -10,11 +10,20 @@ final class ICloudConnectionSyncServiceTests: XCTestCase {
         }
     }
 
+    private final class BoolBox: @unchecked Sendable {
+        var value: Bool
+
+        init(_ value: Bool) {
+            self.value = value
+        }
+    }
+
     private var containerURL: URL!
     private var cloudRootURL: URL!
 
     override func setUp() {
         super.setUp()
+        SharedAppSettings.setICloudSyncEnabled(true)
         containerURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("MFuseCoreICloudLocal-\(UUID().uuidString)", isDirectory: true)
         cloudRootURL = FileManager.default.temporaryDirectory
@@ -28,6 +37,7 @@ final class ICloudConnectionSyncServiceTests: XCTestCase {
         if let cloudRootURL {
             try? FileManager.default.removeItem(at: cloudRootURL)
         }
+        SharedAppSettings.setICloudSyncEnabled(false)
         super.tearDown()
     }
 
@@ -56,7 +66,7 @@ final class ICloudConnectionSyncServiceTests: XCTestCase {
         let result = try await service.synchronize()
 
         XCTAssertEqual(Set(result.liveConnections), Set([localConfig, cloudConfig]))
-        XCTAssertEqual(Set(storage.loadConnections()), Set([localConfig, cloudConfig]))
+        XCTAssertEqual(Set(try storage.loadConnections()), Set([localConfig, cloudConfig]))
     }
 
     func testSynchronizePrefersNewerRecordForSameID() async throws {
@@ -90,7 +100,7 @@ final class ICloudConnectionSyncServiceTests: XCTestCase {
         let result = try await service.synchronize()
 
         XCTAssertEqual(result.liveConnections, [cloudConfig])
-        XCTAssertEqual(storage.loadConnections(), [cloudConfig])
+        XCTAssertEqual(try storage.loadConnections(), [cloudConfig])
     }
 
     func testSynchronizeWritesTombstoneSoDeletedConnectionDoesNotReappear() async throws {
@@ -121,8 +131,9 @@ final class ICloudConnectionSyncServiceTests: XCTestCase {
         let record = try XCTUnwrap(cloudRecordSet.records.first(where: { $0.id == config.id }))
 
         XCTAssertTrue(result.liveConnections.isEmpty)
-        XCTAssertEqual(storage.loadConnections(), [])
+        XCTAssertEqual(try storage.loadConnections(), [])
         XCTAssertEqual(record.deletedAt, dateBox.value)
+        XCTAssertNil(record.config)
     }
 
     func testSynchronizeKeepsDuplicateEndpointsWhenIDsDiffer() async throws {
@@ -201,7 +212,90 @@ final class ICloudConnectionSyncServiceTests: XCTestCase {
 
         XCTAssertEqual(try readCloudRecordSet(), previousCloudState)
         XCTAssertEqual(try readLocalStateRecordSet(), previousLocalState)
-        XCTAssertEqual(storage.loadConnections(), [localConfig])
+        XCTAssertEqual(try storage.loadConnections(), [localConfig])
+    }
+
+    func testSynchronizeRejectsLiveRecordWithoutConfig() async throws {
+        let storage = SharedStorage(containerURL: containerURL)
+        let dateBox = DateBox(Date(timeIntervalSince1970: 1_000))
+        let service = makeService(storage: storage, dateBox: dateBox)
+        let malformedID = UUID()
+
+        try writeCloudRecordSet(
+            ICloudConnectionRecordSet(records: [
+                ICloudConnectionRecord(id: malformedID, config: nil, updatedAt: dateBox.value),
+            ])
+        )
+
+        do {
+            _ = try await service.synchronize()
+            XCTFail("Expected synchronize to fail for a live iCloud record without config")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains(malformedID.uuidString))
+        }
+    }
+
+    func testSynchronizeRetriesWhenLocalConnectionsChangeBeforeWrite() async throws {
+        let storage = SharedStorage(containerURL: containerURL)
+        let dateBox = DateBox(Date(timeIntervalSince1970: 1_000))
+        let didInjectConcurrentChange = BoolBox(false)
+        let localConfig = ConnectionConfig(
+            name: "Local",
+            backendType: .sftp,
+            host: "local.example.com"
+        )
+        let concurrentConfig = ConnectionConfig(
+            name: "Concurrent",
+            backendType: .sftp,
+            host: "concurrent.example.com"
+        )
+        let cloudConfig = ConnectionConfig(
+            name: "Cloud",
+            backendType: .sftp,
+            host: "cloud.example.com"
+        )
+
+        try storage.saveConnections([localConfig])
+        try writeCloudRecordSet(
+            ICloudConnectionRecordSet(records: [
+                ICloudConnectionRecord(id: cloudConfig.id, config: cloudConfig, updatedAt: dateBox.value),
+            ])
+        )
+
+        let service = ICloudConnectionSyncService(
+            storage: storage,
+            ubiquityContainerURLProvider: { [cloudRootURL] in cloudRootURL },
+            keychainAvailabilityProbe: { true },
+            now: { dateBox.value },
+            beforeWritingAttempt: {
+                guard !didInjectConcurrentChange.value else {
+                    return
+                }
+                didInjectConcurrentChange.value = true
+                try storage.saveConnections([localConfig, concurrentConfig])
+            }
+        )
+
+        let result = try await service.synchronize()
+
+        XCTAssertEqual(Set(result.liveConnections), Set([localConfig, concurrentConfig, cloudConfig]))
+        XCTAssertEqual(Set(try storage.loadConnections()), Set([localConfig, concurrentConfig, cloudConfig]))
+        XCTAssertTrue(didInjectConcurrentChange.value)
+    }
+
+    func testSynchronizeThrowsWhenICloudSyncIsDisabled() async throws {
+        let storage = SharedStorage(containerURL: containerURL)
+        let dateBox = DateBox(Date(timeIntervalSince1970: 1_000))
+        let service = makeService(storage: storage, dateBox: dateBox)
+        SharedAppSettings.setICloudSyncEnabled(false)
+
+        do {
+            _ = try await service.synchronize()
+            XCTFail("Expected synchronize to fail when iCloud sync is disabled")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "ICloudConnectionSyncService")
+            XCTAssertEqual((error as NSError).code, 0)
+        }
     }
 
     private func makeService(

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/SharedStorageTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/SharedStorageTests.swift
@@ -56,7 +56,7 @@ final class SharedStorageTests: XCTestCase {
 
         try storage.saveConnections([config])
 
-        XCTAssertEqual(storage.loadConnections(), [config])
+        XCTAssertEqual(try storage.loadConnections(), [config])
         XCTAssertTrue(FileManager.default.fileExists(atPath: storage.connectionsFileURL.path))
     }
 
@@ -79,7 +79,7 @@ final class SharedStorageTests: XCTestCase {
         try storage.saveConnections([first, second])
         try storage.saveConnections([first])
 
-        XCTAssertEqual(storage.loadConnections(), [first])
+        XCTAssertEqual(try storage.loadConnections(), [first])
     }
 
     func testLoadConnectionsMigratesLegacyDefaultsIntoFile() throws {
@@ -96,7 +96,7 @@ final class SharedStorageTests: XCTestCase {
             containerURL: containerURL
         )
 
-        XCTAssertEqual(storage.loadConnections(), [config])
+        XCTAssertEqual(try storage.loadConnections(), [config])
         let fileData = try Data(contentsOf: storage.connectionsFileURL)
         XCTAssertEqual(try JSONDecoder().decode([ConnectionConfig].self, from: fileData), [config])
     }
@@ -115,7 +115,7 @@ final class SharedStorageTests: XCTestCase {
             containerURL: containerURL
         )
 
-        XCTAssertEqual(storage.loadConnections(), [])
+        XCTAssertEqual(try storage.loadConnections(), [])
         XCTAssertFalse(FileManager.default.fileExists(atPath: storage.connectionsFileURL.path))
     }
 
@@ -147,10 +147,25 @@ final class SharedStorageTests: XCTestCase {
         )
         try Data(rawJSON.utf8).write(to: storage.connectionsFileURL, options: .atomic)
 
-        let configs = storage.loadConnections()
+        let configs = try storage.loadConnections()
 
         XCTAssertEqual(configs.count, 1)
         XCTAssertFalse(configs[0].autoMountOnLaunch)
+    }
+
+    func testLoadConnectionsThrowsForCorruptedConnectionsFile() throws {
+        let storage = SharedStorage(
+            legacyDefaults: legacyDefaults,
+            containerURL: containerURL
+        )
+        try FileManager.default.createDirectory(
+            at: storage.connectionsFileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+        try Data("not-json".utf8).write(to: storage.connectionsFileURL, options: .atomic)
+
+        XCTAssertThrowsError(try storage.loadConnections())
     }
 
     func testSharedStorageUsesStandardAppGroupSubdirectories() {
@@ -260,6 +275,51 @@ final class SharedStorageTests: XCTestCase {
 
         XCTAssertEqual(resolved, mirroredCredential)
         XCTAssertNil(primaryCredential)
+    }
+
+    func testMirroredCredentialProviderReportsLocalCredentialState() async throws {
+        let primary = InMemoryCredentialProvider()
+        let sharedStore = SharedCredentialStore(containerURL: containerURL)
+        let connectionID = UUID()
+        let credential = Credential(token: "local-token")
+        let provider = MirroredCredentialProvider(
+            primary: primary,
+            sharedStore: sharedStore,
+            credentialExistenceProbe: { mode, probedConnectionID in
+                mode == .local && probedConnectionID == connectionID
+            }
+        )
+        try await primary.store(credential, for: connectionID)
+        try sharedStore.store(credential, for: connectionID)
+
+        let syncState = try await provider.credentialSyncState(for: [connectionID])
+
+        XCTAssertEqual(syncState, .local)
+    }
+
+    func testMirroredCredentialProviderReportsMixedCredentialStateAcrossModes() async throws {
+        let primary = InMemoryCredentialProvider()
+        let sharedStore = SharedCredentialStore(containerURL: containerURL)
+        let localConnectionID = UUID()
+        let synchronizableConnectionID = UUID()
+        let provider = MirroredCredentialProvider(
+            primary: primary,
+            sharedStore: sharedStore,
+            credentialExistenceProbe: { mode, probedConnectionID in
+                switch (mode, probedConnectionID) {
+                case (.local, localConnectionID), (.synchronizable, synchronizableConnectionID):
+                    true
+                default:
+                    false
+                }
+            }
+        )
+
+        let syncState = try await provider.credentialSyncState(
+            for: [localConnectionID, synchronizableConnectionID]
+        )
+
+        XCTAssertEqual(syncState, .mixed)
     }
 
     func testHostKeyStorePersistsToFileAndMigratesLegacyDefaults() {

--- a/Packages/MFuseFTP/Sources/MFuseFTP/FTPDirectoryParser.swift
+++ b/Packages/MFuseFTP/Sources/MFuseFTP/FTPDirectoryParser.swift
@@ -65,6 +65,7 @@ struct FTPDirectoryParser {
         // Try "Jan 01 12:00" (current year) or "Jan 01  2025"
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
 
         // With time
         formatter.dateFormat = "MMM dd HH:mm"

--- a/Packages/MFuseFTP/Tests/MFuseFTPTests/FTPDirectoryParserTests.swift
+++ b/Packages/MFuseFTP/Tests/MFuseFTPTests/FTPDirectoryParserTests.swift
@@ -89,6 +89,29 @@ final class FTPDirectoryParserTests: XCTestCase {
         XCTAssertNotNil(entries[0].modificationDate)
     }
 
+    func testParseDateWithTimeUsesUTCForParsingAndInference() {
+        let originalTimeZone = NSTimeZone.default
+        NSTimeZone.default = TimeZone(secondsFromGMT: 5 * 60 * 60)!
+        defer { NSTimeZone.default = originalTimeZone }
+
+        let listing = "-rw-r--r--  1 user group  0 Jan 01 00:30 boundary.txt"
+        let entries = FTPDirectoryParser.parse(listing)
+
+        XCTAssertEqual(entries.count, 1)
+        guard let modificationDate = entries[0].modificationDate else {
+            return XCTFail("Expected modification date")
+        }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        let components = calendar.dateComponents([.month, .day, .hour, .minute], from: modificationDate)
+
+        XCTAssertEqual(components.month, 1)
+        XCTAssertEqual(components.day, 1)
+        XCTAssertEqual(components.hour, 0)
+        XCTAssertEqual(components.minute, 30)
+    }
+
     func testParseDateWithYear() {
         let listing = "-rw-r--r--  1 user group  0 Jan 01  2023 old_file.txt"
         let entries = FTPDirectoryParser.parse(listing)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ MFuse is a macOS app that exposes remote storage in Finder through File Provider
 
 Saved mounts can optionally enable `Auto-Mount on App Launch`. When combined with `Launch at Login`, those mounts will reconnect automatically after you sign in or restart your Mac.
 
+MFuse also includes an optional `iCloud Sync` toggle in Settings. When both `iCloud Drive` and `iCloud Keychain` are available, MFuse can sync saved connection configs and credentials across devices. Host keys are still local-only in v1.
+
 ## Screenshots
 
 <table>
@@ -112,6 +114,8 @@ For stable local signing, copy `project.local.example.yml` to `project.local.yml
 
 Unsigned or ad hoc signed builds can still launch, but macOS may ignore the File Provider extension because the App Group entitlement is not accepted at runtime. When that happens, mounts fail and Finder may show missing-file errors for the generated convenience shortcut.
 
+If you want to use `iCloud Sync`, the app target also needs a signing profile that authorizes the `iCloud.com.lollipopkit.mfuse` container and `CloudDocuments`. The File Provider extension does not access the ubiquity container directly, so its entitlement requirements stay limited to the shared App Group and Keychain access group.
+
 ## Common Commands
 
 ```bash
@@ -127,6 +131,8 @@ make clean      # remove build outputs
 `make debug-install-app` runs `scripts/release/build-and-install-app.sh`, archives the `MFuse` scheme in `Debug` using the signing settings already configured in the current `MFuse.xcodeproj`, validates that the archived app and extension embed profiles authorizing the shared App Group, and then installs the archived app to `/Applications/MFuse.app`.
 
 This local install flow now follows the signing configuration that Xcode is already using for the targets. If the current project settings point to explicit provisioning profiles, those profiles still need to authorize `group.com.lollipopkit.mfuse.shared` in `com.apple.security.application-groups`.
+
+When testing `iCloud Sync`, make sure the app target profile also authorizes `iCloud.com.lollipopkit.mfuse`. Regenerate the project from `project.yml` after local signing changes so the checked-in entitlements and your local provisioning setup stay aligned.
 
 The generic `Mac Team Provisioning Profile: *` is not sufficient. It omits the App Group entitlement, which causes macOS Sequoia to show the “would like to access data from other apps” launch prompt, prevents the File Provider extension from appearing in System Settings, and leaves Finder mounts empty or redirected into the shared container. The install script still refuses to copy that broken build into `/Applications`.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,8 @@ MFuse 是一个 macOS 应用，通过 File Provider 把远端存储暴露到 Fin
 
 已保存的挂载现在可以单独勾选 `Auto-Mount on App Launch`。配合 `Launch at Login` 后，这些挂载会在你登录或重启 Mac 后自动重新连接。
 
+MFuse 现在还在设置页提供了可选的 `iCloud Sync` 总开关。只有当 `iCloud Drive` 和 `iCloud Keychain` 都可用时，MFuse 才会跨设备同步已保存的连接配置与凭据；v1 仍然不会同步 host keys。
+
 ## 截图
 
 <table>
@@ -112,6 +114,8 @@ make build
 
 未签名或 ad hoc 签名的构建虽然可以启动，但 macOS 可能会在运行时忽略 File Provider extension，因为 App Group entitlement 不会被系统接受。出现这种情况时，mount 会失败，Finder 还可能对自动生成的便捷链接报“文件不存在”。
 
+如果你要使用 `iCloud Sync`，主应用 target 对应的签名 profile 还需要授权 `iCloud.com.lollipopkit.mfuse` 容器以及 `CloudDocuments`。File Provider extension 不会直接访问 ubiquity container，所以它的 entitlement 需求仍然只包括共享 App Group 和 Keychain access group。
+
 ## 常用命令
 
 ```bash
@@ -127,6 +131,8 @@ make clean      # 清理构建产物
 `make debug-install-app` 会执行 `scripts/release/build-and-install-app.sh`：按当前 `MFuse.xcodeproj` 已配置好的签名设置，以 `Debug` 配置归档 `MFuse` scheme，校验归档里的主应用和扩展都嵌入了已授权共享 App Group 的 profile，然后把归档产物安装到 `/Applications/MFuse.app`。
 
 这个本地安装流程现在直接遵循你在 Xcode 工程里已经配置好的签名方式。如果当前 target 走的是显式 provisioning profile，那么这些 profile 仍然需要在 `com.apple.security.application-groups` 里包含 `group.com.lollipopkit.mfuse.shared`。
+
+如果你要验证 `iCloud Sync`，还要确保主应用 target 的 profile 里包含 `iCloud.com.lollipopkit.mfuse`。修改本地签名配置后，请重新从 `project.yml` 生成工程，避免仓库里的 entitlement 声明和你本机的 provisioning setup 漂移。
 
 通用的 `Mac Team Provisioning Profile: *` 仍然不够用。它不包含 App Group entitlement，在 macOS Sequoia 上会导致 “would like to access data from other apps” 启动弹窗、系统设置里看不到 File Provider 扩展，以及 Finder 挂载为空或被带到共享容器。安装脚本依然会拒绝把这种损坏签名的构建复制到 `/Applications`。
 

--- a/project.yml
+++ b/project.yml
@@ -59,6 +59,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.lollipopkit.mfuse
         INFOPLIST_FILE: MFuse/Info.plist
+        # Keep this entitlements file aligned with App Group and iCloud container capabilities.
         CODE_SIGN_ENTITLEMENTS: MFuse/MFuse.entitlements
         ENABLE_APP_SANDBOX: true
         COMBINE_HIDPI_IMAGES: true


### PR DESCRIPTION
## Summary
- add an iCloud Sync toggle in Settings with availability checks for both iCloud Drive and iCloud Keychain
- sync connection configs through an iCloud-backed record set with timestamps and tombstones while keeping App Group storage as the local runtime mirror
- migrate credentials between local and synchronizable Keychain items when the sync mode changes, and document the new iCloud container entitlement requirements
- fix FTP directory date parsing to use UTC consistently and add regression coverage

## Testing
- swift test (Packages/MFuseCore)
- make build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 可选 iCloud 同步：设置页新增“iCloud Sync”开关、状态与可用性提示，支持凭据迁移、前台/后台与启动时自动同步，开启后会刷新连接列表与选中项；v1 主机密钥仍为本地存储。
  * 增强凭据同步与可用性检测，支持事务性合并、重试与回滚。

* **修复**
  * 目录列表时间解析改为使用 UTC，减少时区偏差。

* **测试**
  * 新增覆盖 iCloud 同步、合并、回滚及并发场景的单元测试。

* **文档**
  * 更新中/英文 README，说明 iCloud 同步及签名/entitlements 要求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->