### PR TITLE
feat: preregister file provider domains

### DIFF
--- a/MFuse/Localizable.xcstrings
+++ b/MFuse/Localizable.xcstrings
@@ -929,6 +929,122 @@
         }
       }
     },
+    "content.error.savedButDomainSyncFailed": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The connection was saved, but File Provider domain sync failed: %@. MFuse will retry reconciliation on the next launch."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "连接已保存，但 File Provider 域同步失败：%@。MFuse 会在下次启动时重试协调。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "連線已儲存，但 File Provider 網域同步失敗：%@。MFuse 會在下次啟動時重試協調。"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La conexión se guardó, pero falló la sincronización del dominio de File Provider: %@. MFuse volverá a intentar la reconciliación en el próximo inicio."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "接続は保存されましたが、File Provider ドメインの同期に失敗しました: %@。MFuse は次回起動時に再調整を再試行します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "연결은 저장되었지만 File Provider 도메인 동기화에 실패했습니다: %@. MFuse는 다음 실행 시 다시 조정합니다."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connessione è stata salvata, ma la sincronizzazione del dominio File Provider non è riuscita: %@. MFuse ritenterà la riconciliazione al prossimo avvio."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Koneksi telah disimpan, tetapi sinkronisasi domain File Provider gagal: %@. MFuse akan mencoba rekonsiliasi lagi saat peluncuran berikutnya."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La connexion a été enregistrée, mais la synchronisation du domaine File Provider a échoué : %@. MFuse réessaiera la réconciliation au prochain lancement."
+          }
+        }
+      }
+    },
+    "content.warning.domainSyncIssue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domain Sync Issue"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "域同步问题"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "網域同步問題"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problema de sincronización del dominio"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ドメイン同期の問題"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "도메인 동기화 문제"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problema di sincronizzazione del dominio"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masalah sinkronisasi domain"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Problème de synchronisation du domaine"
+          }
+        }
+      }
+    },
     "detail.action.openInFinder": {
       "localizations": {
         "en": {
@@ -3899,60 +4015,60 @@
         }
       }
     },
-    "domain.sync.error.removeStaleDomains": {
+    "domain.sync.error.reconcile": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Failed to remove one or more stale File Provider domains: %@"
+            "value": "Failed to reconcile one or more File Provider domains: %@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "移除一个或多个过期 File Provider 域失败：%@"
+            "value": "协调一个或多个 File Provider 域失败：%@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "移除一個或多個過期 File Provider 網域失敗：%@"
+            "value": "協調一個或多個 File Provider 網域失敗：%@"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "No se pudo eliminar uno o más dominios obsoletos de File Provider: %@"
+            "value": "No se pudo reconciliar uno o más dominios de File Provider: %@"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "不要になった File Provider ドメインの削除に失敗しました: %@"
+            "value": "1 つ以上の File Provider ドメインの整合に失敗しました: %@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "오래된 File Provider 도메인 하나 이상을 제거하지 못했습니다: %@"
+            "value": "하나 이상의 File Provider 도메인을 조정하지 못했습니다: %@"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Impossibile rimuovere uno o più domini File Provider obsoleti: %@"
+            "value": "Impossibile riconciliare uno o più domini File Provider: %@"
           }
         },
         "id": {
           "stringUnit": {
             "state": "translated",
-            "value": "Gagal menghapus satu atau lebih domain File Provider yang usang: %@"
+            "value": "Gagal merekonsiliasi satu atau lebih domain File Provider: %@"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Échec de la suppression d’un ou plusieurs domaines File Provider obsolètes : %@"
+            "value": "Échec de la réconciliation d’un ou plusieurs domaines File Provider : %@"
           }
         }
       }

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -137,16 +137,6 @@ public final class DomainManager: ObservableObject {
     private func removeStaleDomainsAndSymlinks() async throws {
         let knownIDs = Set(connectionManager.connections.map(\.domainIdentifier))
         var errors: [SyncDomainsError.Entry] = []
-        let domainStates: [RegisteredDomainState]
-        do {
-            domainStates = try await mountProvider.domainStates()
-        } catch {
-            errors.append(.init(id: "__domain_states__", operation: .listDomains, error: error))
-            Self.logger.error(
-                "Failed to list domain states during stale cleanup: \(String(describing: error), privacy: .public)"
-            )
-            domainStates = []
-        }
         let domains: [NSFileProviderDomain]
 
         do {
@@ -154,6 +144,12 @@ public final class DomainManager: ObservableObject {
         } catch {
             errors.append(.init(id: "__domains__", operation: .listDomains, error: error))
             domains = []
+        }
+        let domainStates = domains.map {
+            RegisteredDomainState(
+                identifier: $0.identifier.rawValue,
+                isDisconnected: $0.isDisconnected
+            )
         }
 
         // Remove stale domains

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MFuseCore
 import FileProvider
+import os.log
 
 /// Bridges ConnectionManager operations with NSFileProviderDomain lifecycle.
 /// Mount/unmount is now handled automatically by ConnectionManager.
@@ -9,6 +10,7 @@ import FileProvider
 public final class DomainManager: ObservableObject {
     private static let replicatedDomainMigrationDefaultsKey =
         "com.lollipopkit.mfuse.fileprovider.replicated-domain-migration-v1"
+    private static let logger = Logger(subsystem: "com.lollipopkit.mfuse", category: "DomainManager")
 
     struct SyncDomainsError: LocalizedError {
         enum Operation: String {
@@ -64,11 +66,20 @@ public final class DomainManager: ObservableObject {
     }
 
     private func reconcileDomainsAndSymlinks() async throws {
-        let existingDomainStates = try await mountProvider.domainStates()
+        var errors: [SyncDomainsError.Entry] = []
+        let existingDomainStates: [RegisteredDomainState]
+        do {
+            existingDomainStates = try await mountProvider.domainStates()
+        } catch {
+            errors.append(.init(id: "__domains__", operation: .listDomains, error: error))
+            Self.logger.error(
+                "Failed to list existing domain states before reconciliation: \(String(describing: error), privacy: .public)"
+            )
+            existingDomainStates = []
+        }
         let existingStatesByID = Dictionary(
             uniqueKeysWithValues: existingDomainStates.map { ($0.identifier, $0) }
         )
-        var errors: [SyncDomainsError.Entry] = []
 
         for config in connectionManager.connections {
             do {

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -76,7 +76,7 @@ public final class DomainManager: ObservableObject {
         } catch {
             errors.append(.init(id: "__domains__", operation: .listDomains, error: error))
             Self.logger.error(
-                "Failed to list existing domain states before reconciliation: \(String(describing: error), privacy: .public)"
+                "Failed to list existing domain states before reconciliation: \(String(describing: error), privacy: .private)"
             )
             existingDomainStates = []
             didLoadExistingDomainStates = false
@@ -109,8 +109,7 @@ public final class DomainManager: ObservableObject {
                 shouldRemainDisconnected = false
             }
 
-            let needsDisconnectCall = shouldRemainDisconnected && existingState?.isDisconnected != true
-            if needsDisconnectCall {
+            if shouldRemainDisconnected {
                 do {
                     try await mountProvider.disconnect(config: config)
                 } catch {
@@ -212,6 +211,8 @@ public final class DomainManager: ObservableObject {
             )
         }
 
+        defaults.set(true, forKey: Self.replicatedDomainMigrationDefaultsKey)
+
         for domainID in domainIDs {
             guard let config = knownConfigsByDomainID[domainID] else { continue }
             do {
@@ -224,7 +225,5 @@ public final class DomainManager: ObservableObject {
         if !errors.isEmpty {
             throw SyncDomainsError(errors: errors)
         }
-
-        defaults.set(true, forKey: Self.replicatedDomainMigrationDefaultsKey)
     }
 }

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -123,7 +123,7 @@ public final class DomainManager: ObservableObject {
             domains = try await NSFileProviderManager.domains()
         } catch {
             errors.append(.init(id: "__domains__", operation: .listDomains, error: error))
-            throw SyncDomainsError(errors: errors)
+            domains = []
         }
 
         // Remove stale domains
@@ -174,6 +174,11 @@ public final class DomainManager: ObservableObject {
 
         do {
             try await NSFileProviderManager.removeAllDomains()
+            // File Provider domain removal completes asynchronously after the API returns.
+            // This fixed delay gives the system time to finish tearing down internal state
+            // before we re-register domains below. A future improvement could replace this
+            // with a configurable constant or a more reliable readiness signal/callback if
+            // Apple exposes one.
             try await Task.sleep(nanoseconds: 500_000_000)
         } catch {
             throw SyncDomainsError(

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -11,13 +11,29 @@ public final class DomainManager: ObservableObject {
         "com.lollipopkit.mfuse.fileprovider.replicated-domain-migration-v1"
 
     struct SyncDomainsError: LocalizedError {
-        let errors: [(id: String, error: Error)]
+        enum Operation: String {
+            case register = "register"
+            case disconnect = "disconnect"
+            case removeStaleDomain = "remove stale domain"
+            case listDomains = "list domains"
+            case removeAllDomains = "remove all domains"
+        }
+
+        struct Entry {
+            let id: String
+            let operation: Operation
+            let error: Error
+        }
+
+        let errors: [Entry]
 
         var errorDescription: String? {
-            let details = errors.map { "\($0.id): \($0.error.localizedDescription)" }.joined(separator: "; ")
+            let details = errors.map {
+                "\($0.operation.rawValue) [\($0.id)]: \($0.error.localizedDescription)"
+            }.joined(separator: "; ")
             return AppL10n.string(
                 "domain.sync.error.removeStaleDomains",
-                fallback: "Failed to remove one or more stale File Provider domains: %@",
+                fallback: "Failed to reconcile one or more File Provider domains: %@",
                 details
             )
         }
@@ -52,13 +68,15 @@ public final class DomainManager: ObservableObject {
         let existingStatesByID = Dictionary(
             uniqueKeysWithValues: existingDomainStates.map { ($0.identifier, $0) }
         )
-        var errors: [(id: String, error: Error)] = []
+        var errors: [SyncDomainsError.Entry] = []
 
         for config in connectionManager.connections {
             do {
                 try await mountProvider.ensureRegistered(config: config)
             } catch {
-                errors.append((id: config.domainIdentifier, error: error))
+                errors.append(
+                    .init(id: config.domainIdentifier, operation: .register, error: error)
+                )
                 continue
             }
 
@@ -72,7 +90,13 @@ public final class DomainManager: ObservableObject {
             }
 
             if shouldRemainDisconnected {
-                try? await mountProvider.disconnect(config: config)
+                do {
+                    try await mountProvider.disconnect(config: config)
+                } catch {
+                    errors.append(
+                        .init(id: config.domainIdentifier, operation: .disconnect, error: error)
+                    )
+                }
             }
         }
 
@@ -80,6 +104,8 @@ public final class DomainManager: ObservableObject {
             try await removeStaleDomainsAndSymlinks()
         } catch let syncError as SyncDomainsError {
             errors.append(contentsOf: syncError.errors)
+        } catch {
+            errors.append(.init(id: "__cleanup__", operation: .listDomains, error: error))
         }
 
         if !errors.isEmpty {
@@ -90,13 +116,13 @@ public final class DomainManager: ObservableObject {
     private func removeStaleDomainsAndSymlinks() async throws {
         let knownIDs = Set(connectionManager.connections.map(\.domainIdentifier))
         let domainStates = try await mountProvider.domainStates()
-        var errors: [(id: String, error: Error)] = []
+        var errors: [SyncDomainsError.Entry] = []
         let domains: [NSFileProviderDomain]
 
         do {
             domains = try await NSFileProviderManager.domains()
         } catch {
-            errors.append((id: "__domains__", error: error))
+            errors.append(.init(id: "__domains__", operation: .listDomains, error: error))
             throw SyncDomainsError(errors: errors)
         }
 
@@ -107,7 +133,9 @@ public final class DomainManager: ObservableObject {
                     try await NSFileProviderManager.remove(domain)
                 }
             } catch {
-                errors.append((id: domainState.identifier, error: error))
+                errors.append(
+                    .init(id: domainState.identifier, operation: .removeStaleDomain, error: error)
+                )
             }
         }
 
@@ -142,13 +170,15 @@ public final class DomainManager: ObservableObject {
         let knownConfigsByDomainID = Dictionary(
             uniqueKeysWithValues: connectionManager.connections.map { ($0.domainIdentifier, $0) }
         )
-        var errors: [(id: String, error: Error)] = []
+        var errors: [SyncDomainsError.Entry] = []
 
         do {
             try await NSFileProviderManager.removeAllDomains()
             try await Task.sleep(nanoseconds: 500_000_000)
         } catch {
-            throw SyncDomainsError(errors: [("__all_domains__", error)])
+            throw SyncDomainsError(
+                errors: [.init(id: "__all_domains__", operation: .removeAllDomains, error: error)]
+            )
         }
 
         for domainID in domainIDs {
@@ -156,7 +186,7 @@ public final class DomainManager: ObservableObject {
             do {
                 try await mountProvider.ensureRegistered(config: config)
             } catch {
-                errors.append((id: domainID, error: error))
+                errors.append(.init(id: domainID, operation: .register, error: error))
             }
         }
 

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -204,14 +204,12 @@ public final class DomainManager: ObservableObject {
             // before we re-register domains below. A future improvement could replace this
             // with a configurable constant or a more reliable readiness signal/callback if
             // Apple exposes one.
-            try await Task.sleep(nanoseconds: 500_000_000)
+            try await Task.sleep(nanoseconds: FileProviderConstants.domainRemovalSettleNanoseconds)
         } catch {
             throw SyncDomainsError(
                 errors: [.init(id: "__all_domains__", operation: .removeAllDomains, error: error)]
             )
         }
-
-        defaults.set(true, forKey: Self.replicatedDomainMigrationDefaultsKey)
 
         for domainID in domainIDs {
             guard let config = knownConfigsByDomainID[domainID] else { continue }
@@ -221,6 +219,8 @@ public final class DomainManager: ObservableObject {
                 errors.append(.init(id: domainID, operation: .register, error: error))
             }
         }
+
+        defaults.set(true, forKey: Self.replicatedDomainMigrationDefaultsKey)
 
         if !errors.isEmpty {
             throw SyncDomainsError(errors: errors)

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -62,7 +62,16 @@ public final class DomainManager: ObservableObject {
                 continue
             }
 
-            if existingStatesByID[config.domainIdentifier]?.isDisconnected != false {
+            let shouldRemainDisconnected: Bool
+            if let existingState = existingStatesByID[config.domainIdentifier] {
+                shouldRemainDisconnected = existingState.isDisconnected
+            } else {
+                // Newly reconciled domains should stay unmounted until the user
+                // explicitly connects them or auto-mount runs.
+                shouldRemainDisconnected = true
+            }
+
+            if shouldRemainDisconnected {
                 try? await mountProvider.disconnect(config: config)
             }
         }

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -32,7 +32,9 @@ public final class DomainManager: ObservableObject {
     }
 
     /// Sync current connections with File Provider domains.
-    /// Reconciles saved connections with File Provider domains.
+    /// Reconciles saved connections with File Provider domains so partial save-time
+    /// registration failures can be retried and stale system state can be cleaned up
+    /// during startup.
     public func syncDomains() async throws {
         try await repairReplicatedDomainRegistrationIfNeeded()
         try await reconcileDomainsAndSymlinks()

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -18,6 +18,7 @@ public final class DomainManager: ObservableObject {
             case disconnect = "disconnect"
             case removeStaleDomain = "remove stale domain"
             case listDomains = "list domains"
+            case cleanup = "cleanup"
             case removeAllDomains = "remove all domains"
         }
 
@@ -34,7 +35,7 @@ public final class DomainManager: ObservableObject {
                 "\($0.operation.rawValue) [\($0.id)]: \($0.error.localizedDescription)"
             }.joined(separator: "; ")
             return AppL10n.string(
-                "domain.sync.error.removeStaleDomains",
+                "domain.sync.error.reconcile",
                 fallback: "Failed to reconcile one or more File Provider domains: %@",
                 details
             )
@@ -68,14 +69,17 @@ public final class DomainManager: ObservableObject {
     private func reconcileDomainsAndSymlinks() async throws {
         var errors: [SyncDomainsError.Entry] = []
         let existingDomainStates: [RegisteredDomainState]
+        let didLoadExistingDomainStates: Bool
         do {
             existingDomainStates = try await mountProvider.domainStates()
+            didLoadExistingDomainStates = true
         } catch {
             errors.append(.init(id: "__domains__", operation: .listDomains, error: error))
             Self.logger.error(
                 "Failed to list existing domain states before reconciliation: \(String(describing: error), privacy: .public)"
             )
             existingDomainStates = []
+            didLoadExistingDomainStates = false
         }
         let existingStatesByID = Dictionary(
             uniqueKeysWithValues: existingDomainStates.map { ($0.identifier, $0) }
@@ -94,10 +98,14 @@ public final class DomainManager: ObservableObject {
             let shouldRemainDisconnected: Bool
             if let existingState = existingStatesByID[config.domainIdentifier] {
                 shouldRemainDisconnected = existingState.isDisconnected
-            } else {
+            } else if didLoadExistingDomainStates {
                 // Newly reconciled domains should stay unmounted until the user
                 // explicitly connects them or auto-mount runs.
                 shouldRemainDisconnected = true
+            } else {
+                // If listing existing domain states failed, avoid disconnecting
+                // potentially active mounts based on an empty snapshot.
+                shouldRemainDisconnected = false
             }
 
             if shouldRemainDisconnected {
@@ -116,7 +124,7 @@ public final class DomainManager: ObservableObject {
         } catch let syncError as SyncDomainsError {
             errors.append(contentsOf: syncError.errors)
         } catch {
-            errors.append(.init(id: "__cleanup__", operation: .listDomains, error: error))
+            errors.append(.init(id: "__cleanup__", operation: .cleanup, error: error))
         }
 
         if !errors.isEmpty {
@@ -126,8 +134,17 @@ public final class DomainManager: ObservableObject {
 
     private func removeStaleDomainsAndSymlinks() async throws {
         let knownIDs = Set(connectionManager.connections.map(\.domainIdentifier))
-        let domainStates = try await mountProvider.domainStates()
         var errors: [SyncDomainsError.Entry] = []
+        let domainStates: [RegisteredDomainState]
+        do {
+            domainStates = try await mountProvider.domainStates()
+        } catch {
+            errors.append(.init(id: "__domain_states__", operation: .listDomains, error: error))
+            Self.logger.error(
+                "Failed to list domain states during stale cleanup: \(String(describing: error), privacy: .public)"
+            )
+            domainStates = []
+        }
         let domains: [NSFileProviderDomain]
 
         do {

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -50,16 +50,30 @@ public final class DomainManager: ObservableObject {
         let existingStatesByID = Dictionary(
             uniqueKeysWithValues: existingDomainStates.map { ($0.identifier, $0) }
         )
+        var errors: [(id: String, error: Error)] = []
 
         for config in connectionManager.connections {
-            try await mountProvider.ensureRegistered(config: config)
+            do {
+                try await mountProvider.ensureRegistered(config: config)
+            } catch {
+                errors.append((id: config.domainIdentifier, error: error))
+                continue
+            }
 
             if existingStatesByID[config.domainIdentifier]?.isDisconnected != false {
                 try? await mountProvider.disconnect(config: config)
             }
         }
 
-        try await removeStaleDomainsAndSymlinks()
+        do {
+            try await removeStaleDomainsAndSymlinks()
+        } catch let syncError as SyncDomainsError {
+            errors.append(contentsOf: syncError.errors)
+        }
+
+        if !errors.isEmpty {
+            throw SyncDomainsError(errors: errors)
+        }
     }
 
     private func removeStaleDomainsAndSymlinks() async throws {

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -32,10 +32,10 @@ public final class DomainManager: ObservableObject {
     }
 
     /// Sync current connections with File Provider domains.
-    /// Removes stale domains that no longer have a corresponding connection.
+    /// Reconciles saved connections with File Provider domains.
     public func syncDomains() async throws {
         try await repairReplicatedDomainRegistrationIfNeeded()
-        try await removeStaleDomainsAndSymlinks()
+        try await reconcileDomainsAndSymlinks()
     }
 
     /// Remove currently registered MFuse domains that do not correspond to a saved connection.
@@ -45,17 +45,37 @@ public final class DomainManager: ObservableObject {
         try await removeStaleDomainsAndSymlinks()
     }
 
+    private func reconcileDomainsAndSymlinks() async throws {
+        let existingDomainStates = try await mountProvider.domainStates()
+        let existingStatesByID = Dictionary(
+            uniqueKeysWithValues: existingDomainStates.map { ($0.identifier, $0) }
+        )
+
+        for config in connectionManager.connections {
+            try await mountProvider.ensureRegistered(config: config)
+
+            if existingStatesByID[config.domainIdentifier]?.isDisconnected != false {
+                try? await mountProvider.disconnect(config: config)
+            }
+        }
+
+        try await removeStaleDomainsAndSymlinks()
+    }
+
     private func removeStaleDomainsAndSymlinks() async throws {
         let knownIDs = Set(connectionManager.connections.map(\.domainIdentifier))
-        let domains = try await NSFileProviderManager.domains()
+        let domainStates = try await mountProvider.domainStates()
         var errors: [(id: String, error: Error)] = []
 
         // Remove stale domains
-        for domain in domains where !knownIDs.contains(domain.identifier.rawValue) {
+        for domainState in domainStates where !knownIDs.contains(domainState.identifier) {
             do {
-                try await NSFileProviderManager.remove(domain)
+                let domains = try await NSFileProviderManager.domains()
+                if let domain = domains.first(where: { $0.identifier.rawValue == domainState.identifier }) {
+                    try await NSFileProviderManager.remove(domain)
+                }
             } catch {
-                errors.append((id: domain.identifier.rawValue, error: error))
+                errors.append((id: domainState.identifier, error: error))
             }
         }
 
@@ -86,7 +106,7 @@ public final class DomainManager: ObservableObject {
         }
 
         let existingDomains = try await NSFileProviderManager.domains()
-        let mountedDomainIDs = Set(existingDomains.map(\.identifier.rawValue))
+        let domainIDs = Set(existingDomains.map(\.identifier.rawValue))
         let knownConfigsByDomainID = Dictionary(
             uniqueKeysWithValues: connectionManager.connections.map { ($0.domainIdentifier, $0) }
         )
@@ -99,10 +119,10 @@ public final class DomainManager: ObservableObject {
             throw SyncDomainsError(errors: [("__all_domains__", error)])
         }
 
-        for domainID in mountedDomainIDs {
+        for domainID in domainIDs {
             guard let config = knownConfigsByDomainID[domainID] else { continue }
             do {
-                try await mountProvider.mount(config: config)
+                try await mountProvider.ensureRegistered(config: config)
             } catch {
                 errors.append((id: domainID, error: error))
             }

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -95,8 +95,9 @@ public final class DomainManager: ObservableObject {
                 continue
             }
 
+            let existingState = existingStatesByID[config.domainIdentifier]
             let shouldRemainDisconnected: Bool
-            if let existingState = existingStatesByID[config.domainIdentifier] {
+            if let existingState {
                 shouldRemainDisconnected = existingState.isDisconnected
             } else if didLoadExistingDomainStates {
                 // Newly reconciled domains should stay unmounted until the user
@@ -108,7 +109,8 @@ public final class DomainManager: ObservableObject {
                 shouldRemainDisconnected = false
             }
 
-            if shouldRemainDisconnected {
+            let needsDisconnectCall = shouldRemainDisconnected && existingState?.isDisconnected != true
+            if needsDisconnectCall {
                 do {
                     try await mountProvider.disconnect(config: config)
                 } catch {

--- a/MFuse/Services/DomainManager.swift
+++ b/MFuse/Services/DomainManager.swift
@@ -82,11 +82,18 @@ public final class DomainManager: ObservableObject {
         let knownIDs = Set(connectionManager.connections.map(\.domainIdentifier))
         let domainStates = try await mountProvider.domainStates()
         var errors: [(id: String, error: Error)] = []
+        let domains: [NSFileProviderDomain]
+
+        do {
+            domains = try await NSFileProviderManager.domains()
+        } catch {
+            errors.append((id: "__domains__", error: error))
+            throw SyncDomainsError(errors: errors)
+        }
 
         // Remove stale domains
         for domainState in domainStates where !knownIDs.contains(domainState.identifier) {
             do {
-                let domains = try await NSFileProviderManager.domains()
                 if let domain = domains.first(where: { $0.identifier.rawValue == domainState.identifier }) {
                     try await NSFileProviderManager.remove(domain)
                 }

--- a/MFuse/Views/ContentView.swift
+++ b/MFuse/Views/ContentView.swift
@@ -8,7 +8,7 @@ struct ContentView: View {
     @State private var selectedConnection: ConnectionConfig?
     @State private var editorPresentation: EditorPresentation?
     @State private var showingExtensionGuide = false
-    @State private var saveErrorMessage: String?
+    @State private var saveAlert: SaveAlertState?
 
     var body: some View {
         NavigationSplitView {
@@ -43,12 +43,14 @@ struct ContentView: View {
                 ExtensionGuideView()
             }
         )
-        .alert(AppL10n.string("content.error.unableToSaveMount", fallback: "Unable to Save Mount"), isPresented: saveErrorIsPresented) {
-            Button(AppL10n.string("common.action.ok", fallback: "OK"), role: .cancel) {
-                saveErrorMessage = nil
-            }
-        } message: {
-            Text(saveErrorMessage ?? AppL10n.string("common.error.unknown", fallback: "An unknown error occurred."))
+        .alert(item: $saveAlert) { alert in
+            Alert(
+                title: Text(alert.title),
+                message: Text(alert.message),
+                dismissButton: .cancel(Text(AppL10n.string("common.action.ok", fallback: "OK"))) {
+                    saveAlert = nil
+                }
+            )
         }
         .onReceive(connectionManager.$needsExtensionSetup) { needs in
             if needs {
@@ -145,34 +147,41 @@ struct ContentView: View {
                     )
                 } catch {
                     await MainActor.run {
-                        saveErrorMessage = AppL10n.string(
-                            "content.error.savedButDomainSyncFailed",
-                            fallback: "The connection was saved, but File Provider domain sync failed: %@. MFuse will retry reconciliation on the next launch.",
-                            error.localizedDescription
+                        saveAlert = SaveAlertState(
+                            title: AppL10n.string(
+                                "content.warning.domainSyncIssue",
+                                fallback: "Domain Sync Issue"
+                            ),
+                            message: AppL10n.string(
+                                "content.error.savedButDomainSyncFailed",
+                                fallback: "The connection was saved, but File Provider domain sync failed: %@. MFuse will retry reconciliation on the next launch.",
+                                error.localizedDescription
+                            )
                         )
                     }
                 }
             } catch {
                 await MainActor.run {
-                    saveErrorMessage = error.localizedDescription
+                    saveAlert = SaveAlertState(
+                        title: AppL10n.string(
+                            "content.error.unableToSaveMount",
+                            fallback: "Unable to Save Mount"
+                        ),
+                        message: error.localizedDescription
+                    )
                 }
             }
         }
-    }
-
-    private var saveErrorIsPresented: Binding<Bool> {
-        Binding(
-            get: { saveErrorMessage != nil },
-            set: { isPresented in
-                if !isPresented {
-                    saveErrorMessage = nil
-                }
-            }
-        )
     }
 }
 
 private struct EditorPresentation: Identifiable {
     let id = UUID()
     let config: ConnectionConfig?
+}
+
+private struct SaveAlertState: Identifiable {
+    let id = UUID()
+    let title: String
+    let message: String
 }

--- a/MFuse/Views/ContentView.swift
+++ b/MFuse/Views/ContentView.swift
@@ -126,10 +126,6 @@ struct ContentView: View {
                     } else {
                         try connectionManager.add(config)
                     }
-                    try await connectionManager.syncSavedConnectionRegistration(
-                        config,
-                        previousConfig: previousConfig
-                    )
                 } catch {
                     if let previousCredential {
                         try? await credentialProvider.store(previousCredential, for: config.id)
@@ -138,6 +134,10 @@ struct ContentView: View {
                     }
                     throw error
                 }
+                try await connectionManager.syncSavedConnectionRegistration(
+                    config,
+                    previousConfig: previousConfig
+                )
                 await MainActor.run {
                     selectedConnection = config
                     editorPresentation = nil

--- a/MFuse/Views/ContentView.swift
+++ b/MFuse/Views/ContentView.swift
@@ -134,13 +134,23 @@ struct ContentView: View {
                     }
                     throw error
                 }
-                try await connectionManager.syncSavedConnectionRegistration(
-                    config,
-                    previousConfig: previousConfig
-                )
                 await MainActor.run {
                     selectedConnection = config
                     editorPresentation = nil
+                }
+                do {
+                    try await connectionManager.syncSavedConnectionRegistration(
+                        config,
+                        previousConfig: previousConfig
+                    )
+                } catch {
+                    await MainActor.run {
+                        saveErrorMessage = AppL10n.string(
+                            "content.error.savedButDomainSyncFailed",
+                            fallback: "The connection was saved, but File Provider domain sync failed: %@. MFuse will retry reconciliation on the next launch.",
+                            error.localizedDescription
+                        )
+                    }
                 }
             } catch {
                 await MainActor.run {

--- a/MFuse/Views/ContentView.swift
+++ b/MFuse/Views/ContentView.swift
@@ -117,14 +117,19 @@ struct ContentView: View {
     private func saveConnection(_ config: ConnectionConfig, credential: Credential) {
         Task {
             do {
+                let previousConfig = connectionManager.connections.first(where: { $0.id == config.id })
                 let previousCredential = try await credentialProvider.credential(for: config.id)
                 try await credentialProvider.store(credential, for: config.id)
                 do {
-                    if connectionManager.connections.contains(where: { $0.id == config.id }) {
+                    if previousConfig != nil {
                         try connectionManager.update(config)
                     } else {
                         try connectionManager.add(config)
                     }
+                    try await connectionManager.syncSavedConnectionRegistration(
+                        config,
+                        previousConfig: previousConfig
+                    )
                 } catch {
                     if let previousCredential {
                         try? await credentialProvider.store(previousCredential, for: config.id)

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
@@ -395,6 +395,10 @@ public final class ConnectionManager: ObservableObject {
 
             do {
                 try await mp.disconnect(config: config)
+            } catch MountError.domainNotFound {
+                logger.notice(
+                    "Skipping disconnect for missing domain \(config.domainIdentifier, privacy: .public)"
+                )
             } catch {
                 let message = "Failed to disconnect domain for \(config.name): \(describe(error))"
                 logger.error(
@@ -556,6 +560,7 @@ public final class ConnectionManager: ObservableObject {
                 nextConnections.append(removedConfig)
                 continue
             }
+            try? await mountProvider?.unregister(config: removedConfig)
 
             states.removeValue(forKey: removedConfig.id)
             mountStates.removeValue(forKey: removedConfig.id)

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
@@ -129,6 +129,10 @@ public final class ConnectionManager: ObservableObject {
         if let mountProvider {
             do {
                 try await mountProvider.unregister(config: config)
+            } catch MountError.domainNotFound {
+                states[config.id] = .disconnected
+                setMountState(.unmounted, for: config)
+                onStateChange?(config, .disconnected)
             } catch {
                 let message = "Failed to unregister \(config.name): \(describe(error))"
                 let errorState = ConnectionState.error(message)
@@ -560,7 +564,21 @@ public final class ConnectionManager: ObservableObject {
                 nextConnections.append(removedConfig)
                 continue
             }
-            try? await mountProvider?.unregister(config: removedConfig)
+            if let mountProvider {
+                do {
+                    try await mountProvider.unregister(config: removedConfig)
+                } catch MountError.domainNotFound {
+                    logger.notice(
+                        "Skipping unregister for missing domain \(removedConfig.domainIdentifier, privacy: .public) during reload cleanup"
+                    )
+                } catch {
+                    logger.error(
+                        "Failed to unregister removed connection \(removedConfig.name, privacy: .private) during reload: \(self.describe(error), privacy: .private)"
+                    )
+                    nextConnections.append(removedConfig)
+                    continue
+                }
+            }
 
             states.removeValue(forKey: removedConfig.id)
             mountStates.removeValue(forKey: removedConfig.id)

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
@@ -144,9 +144,17 @@ public final class ConnectionManager: ObservableObject {
         }
         let previousConnections = connections
         let previousState = states[config.id]
-        let previousMountState = mountStates[config.id]
+       let previousMountState = mountStates[config.id]
         let previousFileSystem = fileSystems[config.id]
-        let savedCredential = try await credentialProvider.credential(for: config.id)
+        let savedCredential: Credential?
+        do {
+            savedCredential = try await credentialProvider.credential(for: config.id)
+        } catch {
+            if let mountProvider {
+                try? await mountProvider.ensureRegistered(config: config)
+            }
+            throw error
+        }
         connections.removeAll { $0.id == config.id }
         states.removeValue(forKey: config.id)
         mountStates.removeValue(forKey: config.id)

--- a/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Connection/ConnectionManager.swift
@@ -41,7 +41,7 @@ public final class ConnectionManager: ObservableObject {
     private var mountResolutionTasks: [UUID: Task<Void, Never>] = [:]
     var staleDomainRemover: ((String) async throws -> Void)?
 
-    /// Optional mount provider – when set, connect() auto-mounts and disconnect() auto-unmounts.
+    /// Optional mount provider – when set, connect() activates a registered domain and disconnect() keeps it registered but disconnected.
     public var mountProvider: (any MountProvider)?
 
     /// Optional callback for state change notifications (connect/disconnect/error).
@@ -126,6 +126,18 @@ public final class ConnectionManager: ObservableObject {
                 throw ConnectionManagerError.cleanupFailed(config.id)
             }
         }
+        if let mountProvider {
+            do {
+                try await mountProvider.unregister(config: config)
+            } catch {
+                let message = "Failed to unregister \(config.name): \(describe(error))"
+                let errorState = ConnectionState.error(message)
+                states[config.id] = errorState
+                setMountState(.error(message), for: config)
+                onStateChange?(config, errorState)
+                throw RemoteFileSystemError.operationFailed(message)
+            }
+        }
         let previousConnections = connections
         let previousState = states[config.id]
         let previousMountState = mountStates[config.id]
@@ -138,6 +150,9 @@ public final class ConnectionManager: ObservableObject {
         do {
             try storage.saveConnections(connections)
         } catch {
+            if let mountProvider {
+                try? await mountProvider.ensureRegistered(config: config)
+            }
             restoreRemovedConnectionState(
                 for: config.id,
                 connections: previousConnections,
@@ -168,6 +183,9 @@ public final class ConnectionManager: ObservableObject {
                         error.localizedDescription
                     )
                 )
+            }
+            if let mountProvider {
+                try? await mountProvider.ensureRegistered(config: config)
             }
             if let savedCredential {
                 do {
@@ -267,10 +285,11 @@ public final class ConnectionManager: ObservableObject {
             if let mp = mountProvider {
                 setMountState(.mounting, for: config)
                 do {
-                    try await mp.mount(config: config)
+                    try await mp.ensureRegistered(config: config)
+                    try await mp.reconnect(config: config)
                     guard isCurrentConnectionAttempt(for: id, generation: localGeneration),
                           !interruptedConnectionIDs.contains(id) else {
-                        try? await mp.unmount(config: config)
+                        try? await mp.disconnect(config: config)
                         try? await fs.disconnect()
                         return
                     }
@@ -375,11 +394,11 @@ public final class ConnectionManager: ObservableObject {
             }
 
             do {
-                try await mp.unmount(config: config)
+                try await mp.disconnect(config: config)
             } catch {
-                let message = "Failed to unmount \(config.name): \(describe(error))"
+                let message = "Failed to disconnect domain for \(config.name): \(describe(error))"
                 logger.error(
-                    "Failed to unmount connection \(config.name, privacy: .private): \(self.describe(error), privacy: .private)"
+                    "Failed to disconnect domain for connection \(config.name, privacy: .private): \(self.describe(error), privacy: .private)"
                 )
                 cleanupFailures.append(message)
             }
@@ -612,11 +631,14 @@ public final class ConnectionManager: ObservableObject {
     public func syncMounts() async {
         guard let mp = mountProvider else { return }
         do {
-            let domainIDs = try await mp.mountedDomains()
+            let domainStates = try await mp.domainStates()
+            let domainStatesByID = Dictionary(
+                uniqueKeysWithValues: domainStates.map { ($0.identifier, $0) }
+            )
             let knownDomainIDs = Set(connections.map(\.domainIdentifier))
 
             // Remove stale domains
-            for domainID in domainIDs where !knownDomainIDs.contains(domainID) {
+            for domainID in domainStatesByID.keys where !knownDomainIDs.contains(domainID) {
                 let remover = staleDomainRemover ?? _removeStaleProviderDomain
                 try? await remover(domainID)
             }
@@ -625,7 +647,15 @@ public final class ConnectionManager: ObservableObject {
 
             // Rebuild mount states and symlinks for existing mounted configs
             for config in connections {
-                if domainIDs.contains(config.domainIdentifier) {
+                if let domainState = domainStatesByID[config.domainIdentifier] {
+                    if domainState.isDisconnected {
+                        mountResolutionTasks[config.id]?.cancel()
+                        mountResolutionTasks.removeValue(forKey: config.id)
+                        setMountState(.unmounted, for: config)
+                        try? await mp.removeSymlink(for: config)
+                        continue
+                    }
+
                     setMountState(.mounting, for: config)
                     do {
                         try await mp.signalEnumerator(for: config)
@@ -687,6 +717,30 @@ public final class ConnectionManager: ObservableObject {
         for config in targets {
             await connect(config.id)
         }
+    }
+
+    public func syncSavedConnectionRegistration(
+        _ config: ConnectionConfig,
+        previousConfig: ConnectionConfig?
+    ) async throws {
+        guard let mountProvider else { return }
+
+        let wasMounted = previousConfig.map { effectiveMountState(for: $0.id).isMounted } ?? false
+        try await mountProvider.ensureRegistered(config: config)
+
+        if wasMounted {
+            await disconnect(config.id, using: previousConfig)
+            await connect(config.id)
+            return
+        }
+
+        if let previousConfig, previousConfig.name != config.name {
+            try? await mountProvider.removeSymlink(for: previousConfig)
+        }
+
+        try? await mountProvider.removeSymlink(for: config)
+        try await mountProvider.disconnect(config: config)
+        setMountState(.unmounted, for: config)
     }
 
     private func _removeStaleProviderDomain(id: String) async throws {

--- a/Packages/MFuseCore/Sources/MFuseCore/Mount/FileProviderConstants.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Mount/FileProviderConstants.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public enum FileProviderConstants {
+    public static let domainRemovalSettleNanoseconds: UInt64 = 500_000_000
+}

--- a/Packages/MFuseCore/Sources/MFuseCore/Mount/FileProviderMountProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Mount/FileProviderMountProvider.swift
@@ -23,7 +23,8 @@ public final class FileProviderMountProvider: MountProvider {
         self.symlinkBaseURL = symlinkBaseURL
     }
 
-    public func mount(config: ConnectionConfig) async throws {
+    public func ensureRegistered(config: ConnectionConfig) async throws {
+        let existingDomain = try await findDomain(for: config)
         let domain = try makeDomain(for: config)
 
         do {
@@ -56,35 +57,60 @@ public final class FileProviderMountProvider: MountProvider {
         do {
             try persistBootstrapConfig(for: config)
         } catch {
-            let persistError = error
-            do {
-                try await NSFileProviderManager.remove(domain)
-            } catch {
-                let rollbackError = error
-                Self.logger.error(
-                    "persistBootstrapConfig(for:) failed for domain \(domain.identifier.rawValue, privacy: .public): \(persistError.localizedDescription, privacy: .public); rollback via NSFileProviderManager.remove(domain) also failed: \(rollbackError.localizedDescription, privacy: .public)"
-                )
-                throw MountError.mountFailed(
-                    "persistBootstrapConfig(for:) failed for \(domain.identifier.rawValue): \(persistError.localizedDescription); rollback via NSFileProviderManager.remove(domain) failed: \(rollbackError.localizedDescription)"
-                )
+            if existingDomain == nil {
+                let persistError = error
+                do {
+                    try await NSFileProviderManager.remove(domain)
+                } catch {
+                    let rollbackError = error
+                    Self.logger.error(
+                        "persistBootstrapConfig(for:) failed for domain \(domain.identifier.rawValue, privacy: .public): \(persistError.localizedDescription, privacy: .public); rollback via NSFileProviderManager.remove(domain) also failed: \(rollbackError.localizedDescription, privacy: .public)"
+                    )
+                    throw MountError.mountFailed(
+                        "persistBootstrapConfig(for:) failed for \(domain.identifier.rawValue): \(persistError.localizedDescription); rollback via NSFileProviderManager.remove(domain) failed: \(rollbackError.localizedDescription)"
+                    )
+                }
             }
-            throw persistError
+            throw error
         }
     }
 
-    public func unmount(config: ConnectionConfig) async throws {
-        let domainID = NSFileProviderDomainIdentifier(rawValue: config.domainIdentifier)
-        let domains = try await NSFileProviderManager.domains()
-        guard let domain = domains.first(where: { $0.identifier == domainID }) else {
-            throw MountError.domainNotFound(config.domainIdentifier)
+    public func unregister(config: ConnectionConfig) async throws {
+        if let domain = try await findDomain(for: config) {
+            try await NSFileProviderManager.remove(domain)
         }
-        try await NSFileProviderManager.remove(domain)
         try removeBootstrapConfig(for: config)
     }
 
-    public func mountedDomains() async throws -> [String] {
+    public func reconnect(config: ConnectionConfig) async throws {
+        let domain = try await domainOrThrow(for: config)
+        try persistBootstrapConfig(for: config)
+        guard let manager = NSFileProviderManager(for: domain) else {
+            throw MountError.managerNotFound(config.domainIdentifier)
+        }
+        try await manager.reconnect()
+    }
+
+    public func disconnect(config: ConnectionConfig) async throws {
+        let domain = try await domainOrThrow(for: config)
+        try persistBootstrapConfig(for: config)
+        guard let manager = NSFileProviderManager(for: domain) else {
+            throw MountError.managerNotFound(config.domainIdentifier)
+        }
+        try await manager.disconnect(
+            reason: "Disconnected from MFuse",
+            options: []
+        )
+    }
+
+    public func domainStates() async throws -> [RegisteredDomainState] {
         let domains = try await NSFileProviderManager.domains()
-        return domains.map(\.identifier.rawValue)
+        return domains.map {
+            RegisteredDomainState(
+                identifier: $0.identifier.rawValue,
+                isDisconnected: $0.isDisconnected
+            )
+        }
     }
 
     public func signalEnumerator(for config: ConnectionConfig) async throws {

--- a/Packages/MFuseCore/Sources/MFuseCore/Mount/FileProviderMountProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Mount/FileProviderMountProvider.swift
@@ -36,7 +36,7 @@ public final class FileProviderMountProvider: MountProvider {
             if shouldRetryMountAfterDomainRefresh(error) {
                 if let stale = try await findDomain(for: config) {
                     try await NSFileProviderManager.remove(stale)
-                    try await Task.sleep(nanoseconds: 500_000_000)
+                    try await Task.sleep(nanoseconds: FileProviderConstants.domainRemovalSettleNanoseconds)
                 }
                 try Task.checkCancellation()
                 try await Task.sleep(nanoseconds: 1_000_000_000)

--- a/Packages/MFuseCore/Sources/MFuseCore/Mount/MountProvider.swift
+++ b/Packages/MFuseCore/Sources/MFuseCore/Mount/MountProvider.swift
@@ -90,20 +90,40 @@ public enum MountState: Sendable, Equatable {
     }
 }
 
+public struct RegisteredDomainState: Sendable, Equatable {
+    public let identifier: String
+    public let isDisconnected: Bool
+
+    public init(identifier: String, isDisconnected: Bool) {
+        self.identifier = identifier
+        self.isDisconnected = isDisconnected
+    }
+
+    public var isConnected: Bool {
+        !isDisconnected
+    }
+}
+
 /// Abstraction over the mounting mechanism.
 public protocol MountProvider: Sendable {
 
     /// Base directory used for convenience symlinks.
     var symlinkBaseURL: URL { get }
 
-    /// Mount a connection, making it visible in Finder / filesystem.
-    func mount(config: ConnectionConfig) async throws
+    /// Ensure a File Provider domain exists for the connection and refresh bootstrap state.
+    func ensureRegistered(config: ConnectionConfig) async throws
 
-    /// Unmount a previously mounted connection.
-    func unmount(config: ConnectionConfig) async throws
+    /// Remove the File Provider domain for the connection.
+    func unregister(config: ConnectionConfig) async throws
 
-    /// List currently mounted domain identifiers.
-    func mountedDomains() async throws -> [String]
+    /// Reconnect a registered domain so the extension becomes active again.
+    func reconnect(config: ConnectionConfig) async throws
+
+    /// Disconnect a registered domain while keeping it registered.
+    func disconnect(config: ConnectionConfig) async throws
+
+    /// List currently registered domains and whether they are disconnected.
+    func domainStates() async throws -> [RegisteredDomainState]
 
     /// Signal the system to re-enumerate a domain (e.g. after changes).
     func signalEnumerator(for config: ConnectionConfig) async throws
@@ -117,4 +137,12 @@ public protocol MountProvider: Sendable {
 
     /// Remove the convenience symlink for a connection.
     func removeSymlink(for config: ConnectionConfig) async throws
+}
+
+public extension MountProvider {
+    func mountedDomains() async throws -> [String] {
+        try await domainStates()
+            .filter(\.isConnected)
+            .map(\.identifier)
+    }
 }

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
@@ -163,6 +163,9 @@ actor MockMountProvider: MountProvider {
     }
 
     func unregister(config: ConnectionConfig) async throws {
+        guard registeredDomainIDs.contains(config.domainIdentifier) else {
+            throw MountError.domainNotFound(config.domainIdentifier)
+        }
         unregisterInvocations.append(config.domainIdentifier)
         if unmountShouldFail {
             throw MountError.unmountFailed("mock unmount failure")
@@ -181,12 +184,12 @@ actor MockMountProvider: MountProvider {
     }
 
     func disconnect(config: ConnectionConfig) async throws {
+        guard registeredDomainIDs.contains(config.domainIdentifier) else {
+            throw MountError.domainNotFound(config.domainIdentifier)
+        }
         disconnectInvocations.append(config.domainIdentifier)
         if unmountShouldFail {
             throw MountError.unmountFailed("mock unmount failure")
-        }
-        guard registeredDomainIDs.contains(config.domainIdentifier) else {
-            throw MountError.domainNotFound(config.domainIdentifier)
         }
         disconnectedDomainIDs.insert(config.domainIdentifier)
     }
@@ -587,6 +590,29 @@ final class ConnectionManagerTests: XCTestCase {
         XCTAssertTrue(disconnectCalled)
     }
 
+    func testReloadConnectionsFromStorageUnregistersRemovedDomainAfterCleanup() async throws {
+        let config = ConnectionConfig(
+            name: "ReloadRemoved",
+            backendType: .sftp,
+            host: "example.com",
+            username: "user"
+        )
+        let mountProvider = MockMountProvider(symlinkBaseURL: testSymlinkBaseURL)
+        manager.mountProvider = mountProvider
+        credentialProvider.credentials[config.id] = Credential(password: "pass")
+        try manager.add(config)
+        await manager.connect(config.id)
+        try storage.saveConnections([])
+
+        await manager.reloadConnectionsFromStorage()
+
+        XCTAssertFalse(manager.connections.contains(where: { $0.id == config.id }))
+        let unregisterInvocations = await mountProvider.unregisterInvocations
+        XCTAssertEqual(unregisterInvocations, [config.domainIdentifier])
+        let domainStates = try await mountProvider.domainStates()
+        XCTAssertTrue(domainStates.isEmpty)
+    }
+
     func testConnectSuccess() async throws {
         let config = ConnectionConfig(
             name: "Test",
@@ -755,6 +781,27 @@ final class ConnectionManagerTests: XCTestCase {
         XCTAssertTrue(message.contains("mock unmount failure"))
         XCTAssertNil(manager.fileSystem(for: config.id))
         XCTAssertEqual(manager.mountState(for: config.id), .error(message))
+    }
+
+    func testDisconnectTreatsMissingDomainAsAlreadyCleanedUp() async throws {
+        let config = ConnectionConfig(
+            name: "MissingDomain",
+            backendType: .sftp,
+            host: "example.com",
+            username: "user"
+        )
+        let mountProvider = MockMountProvider(symlinkBaseURL: testSymlinkBaseURL)
+        manager.mountProvider = mountProvider
+        credentialProvider.credentials[config.id] = Credential(password: "pass")
+        try manager.add(config)
+
+        await manager.connect(config.id)
+        await mountProvider.setDomainStates([])
+        await manager.disconnect(config.id)
+
+        XCTAssertEqual(manager.state(for: config.id), .disconnected)
+        XCTAssertEqual(manager.mountState(for: config.id), .unmounted)
+        XCTAssertNil(manager.fileSystem(for: config.id))
     }
 
     func testSyncSavedConnectionRegistrationKeepsPreregisteredDomainUnmounted() async throws {

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
@@ -124,6 +124,7 @@ actor MockMountProvider: MountProvider {
     var nilMountURLCounts: [String: Int] = [:]
     var staleDomainsRemoved: [String] = []
     var unmountShouldFail = false
+    var unregisterShouldFail = false
     var removeSymlinkShouldFail = false
 
     init(symlinkBaseURL: URL) {
@@ -153,6 +154,10 @@ actor MockMountProvider: MountProvider {
         unmountShouldFail = shouldFail
     }
 
+    func setUnregisterShouldFail(_ shouldFail: Bool) {
+        unregisterShouldFail = shouldFail
+    }
+
     func setRemoveSymlinkShouldFail(_ shouldFail: Bool) {
         removeSymlinkShouldFail = shouldFail
     }
@@ -167,7 +172,7 @@ actor MockMountProvider: MountProvider {
             throw MountError.domainNotFound(config.domainIdentifier)
         }
         unregisterInvocations.append(config.domainIdentifier)
-        if unmountShouldFail {
+        if unregisterShouldFail {
             throw MountError.unmountFailed("mock unmount failure")
         }
         registeredDomainIDs.remove(config.domainIdentifier)
@@ -537,6 +542,29 @@ final class ConnectionManagerTests: XCTestCase {
         XCTAssertEqual(try storage.loadConnections(), [config])
     }
 
+    func testRemoveConnectionSucceedsWhenDomainAlreadyMissing() async throws {
+        let config = ConnectionConfig(
+            name: "MissingDomainRemoval",
+            backendType: .sftp,
+            host: "example.com",
+            username: "user"
+        )
+        let mountProvider = MockMountProvider(symlinkBaseURL: testSymlinkBaseURL)
+        manager.mountProvider = mountProvider
+        credentialProvider.credentials[config.id] = Credential(password: "pass")
+        try manager.add(config)
+
+        await manager.connect(config.id)
+        await mountProvider.setDomainStates([])
+
+        try await manager.remove(config)
+
+        XCTAssertTrue(manager.connections.isEmpty)
+        XCTAssertNil(manager.fileSystem(for: config.id))
+        XCTAssertNil(credentialProvider.credentials[config.id])
+        XCTAssertTrue(try storage.loadConnections().isEmpty)
+    }
+
     func testReloadConnectionsFromStorageSkipsCleanupWhenReloadFails() async throws {
         let config = ConnectionConfig(
             name: "ReloadFailure",
@@ -611,6 +639,29 @@ final class ConnectionManagerTests: XCTestCase {
         XCTAssertEqual(unregisterInvocations, [config.domainIdentifier])
         let domainStates = try await mountProvider.domainStates()
         XCTAssertTrue(domainStates.isEmpty)
+    }
+
+    func testReloadConnectionsFromStoragePreservesRuntimeStateWhenUnregisterFails() async throws {
+        let config = ConnectionConfig(
+            name: "ReloadUnregisterFailure",
+            backendType: .sftp,
+            host: "example.com",
+            username: "user"
+        )
+        let mountProvider = MockMountProvider(symlinkBaseURL: testSymlinkBaseURL)
+        manager.mountProvider = mountProvider
+        credentialProvider.credentials[config.id] = Credential(password: "pass")
+        try manager.add(config)
+        await manager.connect(config.id)
+        await mountProvider.setUnregisterShouldFail(true)
+        try storage.saveConnections([])
+
+        await manager.reloadConnectionsFromStorage()
+
+        XCTAssertEqual(manager.connections, [config])
+        XCTAssertEqual(manager.state(for: config.id), .disconnected)
+        let unregisterInvocations = await mountProvider.unregisterInvocations
+        XCTAssertEqual(unregisterInvocations, [config.domainIdentifier])
     }
 
     func testConnectSuccess() async throws {

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
@@ -174,7 +174,9 @@ actor MockMountProvider: MountProvider {
 
     func reconnect(config: ConnectionConfig) async throws {
         reconnectInvocations.append(config.domainIdentifier)
-        registeredDomainIDs.insert(config.domainIdentifier)
+        guard registeredDomainIDs.contains(config.domainIdentifier) else {
+            throw MountError.domainNotFound(config.domainIdentifier)
+        }
         disconnectedDomainIDs.remove(config.domainIdentifier)
     }
 

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
@@ -160,7 +160,6 @@ actor MockMountProvider: MountProvider {
     func ensureRegistered(config: ConnectionConfig) async throws {
         ensureRegisteredInvocations.append(config.domainIdentifier)
         registeredDomainIDs.insert(config.domainIdentifier)
-        disconnectedDomainIDs.remove(config.domainIdentifier)
     }
 
     func unregister(config: ConnectionConfig) async throws {

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
@@ -168,9 +168,6 @@ actor MockMountProvider: MountProvider {
     }
 
     func unregister(config: ConnectionConfig) async throws {
-        guard registeredDomainIDs.contains(config.domainIdentifier) else {
-            throw MountError.domainNotFound(config.domainIdentifier)
-        }
         unregisterInvocations.append(config.domainIdentifier)
         if unregisterShouldFail {
             throw MountError.unmountFailed("mock unmount failure")
@@ -181,10 +178,10 @@ actor MockMountProvider: MountProvider {
     }
 
     func reconnect(config: ConnectionConfig) async throws {
-        reconnectInvocations.append(config.domainIdentifier)
         guard registeredDomainIDs.contains(config.domainIdentifier) else {
             throw MountError.domainNotFound(config.domainIdentifier)
         }
+        reconnectInvocations.append(config.domainIdentifier)
         disconnectedDomainIDs.remove(config.domainIdentifier)
     }
 

--- a/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
+++ b/Packages/MFuseCore/Tests/MFuseCoreTests/ConnectionManagerTests.swift
@@ -110,9 +110,12 @@ actor MockFileSystem: RemoteFileSystem {
 
 actor MockMountProvider: MountProvider {
     let symlinkBaseURL: URL
-    var mountedDomainIDs: [String] = []
-    var mountInvocations: [String] = []
-    var unmountInvocations: [String] = []
+    var registeredDomainIDs: Set<String> = []
+    var disconnectedDomainIDs: Set<String> = []
+    var ensureRegisteredInvocations: [String] = []
+    var unregisterInvocations: [String] = []
+    var reconnectInvocations: [String] = []
+    var disconnectInvocations: [String] = []
     var signalInvocations: [String] = []
     var mountURLs: [String: URL] = [:]
     var createSymlinkInvocations: [String] = []
@@ -127,8 +130,11 @@ actor MockMountProvider: MountProvider {
         self.symlinkBaseURL = symlinkBaseURL
     }
 
-    func setMountedDomainIDs(_ ids: [String]) {
-        mountedDomainIDs = ids
+    func setDomainStates(_ states: [RegisteredDomainState]) {
+        registeredDomainIDs = Set(states.map(\.identifier))
+        disconnectedDomainIDs = Set(
+            states.filter(\.isDisconnected).map(\.identifier)
+        )
     }
 
     func setMountURL(_ url: URL, for domainID: String) {
@@ -151,24 +157,46 @@ actor MockMountProvider: MountProvider {
         removeSymlinkShouldFail = shouldFail
     }
 
-    func mount(config: ConnectionConfig) async throws {
-        mountInvocations.append(config.domainIdentifier)
-        if !mountedDomainIDs.contains(config.domainIdentifier) {
-            mountedDomainIDs.append(config.domainIdentifier)
-        }
+    func ensureRegistered(config: ConnectionConfig) async throws {
+        ensureRegisteredInvocations.append(config.domainIdentifier)
+        registeredDomainIDs.insert(config.domainIdentifier)
+        disconnectedDomainIDs.remove(config.domainIdentifier)
     }
 
-    func unmount(config: ConnectionConfig) async throws {
-        unmountInvocations.append(config.domainIdentifier)
+    func unregister(config: ConnectionConfig) async throws {
+        unregisterInvocations.append(config.domainIdentifier)
         if unmountShouldFail {
             throw MountError.unmountFailed("mock unmount failure")
         }
-        mountedDomainIDs.removeAll { $0 == config.domainIdentifier }
+        registeredDomainIDs.remove(config.domainIdentifier)
+        disconnectedDomainIDs.remove(config.domainIdentifier)
         removedDomains.append(config.domainIdentifier)
     }
 
-    func mountedDomains() async throws -> [String] {
-        mountedDomainIDs
+    func reconnect(config: ConnectionConfig) async throws {
+        reconnectInvocations.append(config.domainIdentifier)
+        registeredDomainIDs.insert(config.domainIdentifier)
+        disconnectedDomainIDs.remove(config.domainIdentifier)
+    }
+
+    func disconnect(config: ConnectionConfig) async throws {
+        disconnectInvocations.append(config.domainIdentifier)
+        if unmountShouldFail {
+            throw MountError.unmountFailed("mock unmount failure")
+        }
+        guard registeredDomainIDs.contains(config.domainIdentifier) else {
+            throw MountError.domainNotFound(config.domainIdentifier)
+        }
+        disconnectedDomainIDs.insert(config.domainIdentifier)
+    }
+
+    func domainStates() async throws -> [RegisteredDomainState] {
+        registeredDomainIDs.map {
+            RegisteredDomainState(
+                identifier: $0,
+                isDisconnected: disconnectedDomainIDs.contains($0)
+            )
+        }
     }
 
     func signalEnumerator(for config: ConnectionConfig) async throws {
@@ -728,6 +756,26 @@ final class ConnectionManagerTests: XCTestCase {
         XCTAssertEqual(manager.mountState(for: config.id), .error(message))
     }
 
+    func testSyncSavedConnectionRegistrationKeepsPreregisteredDomainUnmounted() async throws {
+        let config = ConnectionConfig(
+            name: "saved",
+            backendType: .sftp,
+            host: "example.com"
+        )
+        let mountProvider = MockMountProvider(symlinkBaseURL: testSymlinkBaseURL)
+        manager.mountProvider = mountProvider
+        try manager.add(config)
+
+        try await manager.syncSavedConnectionRegistration(config, previousConfig: nil)
+
+        XCTAssertEqual(manager.effectiveMountState(for: config.id), .unmounted)
+        let domainStates = try await mountProvider.domainStates()
+        XCTAssertEqual(
+            domainStates,
+            [RegisteredDomainState(identifier: config.domainIdentifier, isDisconnected: true)]
+        )
+    }
+
     func testReconnectSkipsConnectWhenAlreadyConnectedBeforeRetryFires() async throws {
         let config = ConnectionConfig(
             name: "ReconnectSkip",
@@ -861,7 +909,9 @@ final class ConnectionManagerTests: XCTestCase {
         let mountURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("mounted-restore-\(UUID().uuidString)")
         try? FileManager.default.createDirectory(at: mountURL, withIntermediateDirectories: true)
-        await mountProvider.setMountedDomainIDs([config.domainIdentifier])
+        await mountProvider.setDomainStates([
+            RegisteredDomainState(identifier: config.domainIdentifier, isDisconnected: false)
+        ])
         await mountProvider.setMountURL(mountURL, for: config.domainIdentifier)
         manager.mountProvider = mountProvider
         try manager.add(config)
@@ -886,7 +936,10 @@ final class ConnectionManagerTests: XCTestCase {
         )
         let mountProvider = MockMountProvider(symlinkBaseURL: testSymlinkBaseURL)
         let orphanDomainID = UUID().uuidString
-        await mountProvider.setMountedDomainIDs([config.domainIdentifier, orphanDomainID])
+        await mountProvider.setDomainStates([
+            RegisteredDomainState(identifier: config.domainIdentifier, isDisconnected: false),
+            RegisteredDomainState(identifier: orphanDomainID, isDisconnected: false)
+        ])
         let orphanSymlinkURL = testSymlinkBaseURL.appendingPathComponent("orphan-\(UUID().uuidString)")
         let orphanTargetURL = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library", isDirectory: true)
@@ -948,8 +1001,72 @@ final class ConnectionManagerTests: XCTestCase {
         XCTAssertEqual(mountedState, .mounted(path: autoMountURL.path))
         XCTAssertEqual(manager.state(for: manualConfig.id), .disconnected)
         XCTAssertEqual(manager.mountState(for: manualConfig.id), .unmounted)
-        let mountInvocations = await mountProvider.mountInvocations
-        XCTAssertEqual(mountInvocations, [autoConfig.domainIdentifier])
+        let reconnectInvocations = await mountProvider.reconnectInvocations
+        XCTAssertEqual(reconnectInvocations, [autoConfig.domainIdentifier])
+    }
+
+    func testAutoMountConfiguredConnectionsReconnectsDisconnectedRegisteredDomain() async throws {
+        let config = ConnectionConfig(
+            name: "auto-registered",
+            backendType: .sftp,
+            host: "auto.example.com",
+            username: "user",
+            autoMountOnLaunch: true
+        )
+        let mountProvider = MockMountProvider(symlinkBaseURL: testSymlinkBaseURL)
+        let mountURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("auto-registered-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: mountURL, withIntermediateDirectories: true)
+        await mountProvider.setDomainStates([
+            RegisteredDomainState(identifier: config.domainIdentifier, isDisconnected: true)
+        ])
+        await mountProvider.setMountURL(mountURL, for: config.domainIdentifier)
+        manager.mountProvider = mountProvider
+        credentialProvider.credentials[config.id] = Credential(password: "pass")
+        try manager.add(config)
+
+        XCTAssertEqual(manager.effectiveMountState(for: config.id), .unmounted)
+
+        await manager.autoMountConfiguredConnections()
+
+        let mountedState = await waitForMountState(config.id)
+        XCTAssertEqual(mountedState, .mounted(path: mountURL.path))
+        let reconnectInvocations = await mountProvider.reconnectInvocations
+        XCTAssertEqual(reconnectInvocations, [config.domainIdentifier])
+    }
+
+    func testDisconnectKeepsDomainRegisteredButRemovesSymlink() async throws {
+        let config = ConnectionConfig(
+            name: "registered",
+            backendType: .sftp,
+            host: "example.com",
+            username: "user"
+        )
+        let mountProvider = MockMountProvider(symlinkBaseURL: testSymlinkBaseURL)
+        let mountURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("disconnect-registered-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: mountURL, withIntermediateDirectories: true)
+        await mountProvider.setMountURL(mountURL, for: config.domainIdentifier)
+        manager.mountProvider = mountProvider
+        credentialProvider.credentials[config.id] = Credential(password: "pass")
+        try manager.add(config)
+
+        await manager.connect(config.id)
+        _ = await waitForMountState(config.id)
+
+        let symlinkURL = testSymlinkBaseURL
+            .appendingPathComponent(FileProviderMountProvider.symlinkFilename(for: config))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: symlinkURL.path))
+
+        await manager.disconnect(config.id)
+
+        XCTAssertEqual(manager.mountState(for: config.id), .unmounted)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: symlinkURL.path))
+        let domainStates = try await mountProvider.domainStates()
+        XCTAssertEqual(
+            domainStates,
+            [RegisteredDomainState(identifier: config.domainIdentifier, isDisconnected: true)]
+        )
     }
 
     private func waitForMountState(_ id: UUID) async -> MountState {

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ MFuse is a macOS app that exposes remote storage in Finder through File Provider
 
 Saved mounts can optionally enable `Auto-Mount on App Launch`. When combined with `Launch at Login`, those mounts will reconnect automatically after you sign in or restart your Mac.
 
+Saving a connection now pre-registers its File Provider domain, so MFuse can appear in System Settings before the first mount. `Unmount` only disconnects the active session and keeps the domain registered; the domain is removed only when you delete the saved connection.
+
 MFuse also includes an optional `iCloud Sync` toggle in Settings. When both `iCloud Drive` and `iCloud Keychain` are available, MFuse can sync saved connection configs and credentials across devices. Host keys are still local-only in v1.
 
 ## Screenshots

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,8 @@ MFuse 是一个 macOS 应用，通过 File Provider 把远端存储暴露到 Fin
 
 已保存的挂载现在可以单独勾选 `Auto-Mount on App Launch`。配合 `Launch at Login` 后，这些挂载会在你登录或重启 Mac 后自动重新连接。
 
+现在保存连接时会立即预注册对应的 File Provider domain，因此即使还没有第一次挂载，系统设置里也能先看到 MFuse。`Unmount` 现在只会断开当前会话并保留 domain；只有删除已保存连接时，系统中的 domain 才会真正移除。
+
 MFuse 现在还在设置页提供了可选的 `iCloud Sync` 总开关。只有当 `iCloud Drive` 和 `iCloud Keychain` 都可用时，MFuse 才会跨设备同步已保存的连接配置与凭据；v1 仍然不会同步 host keys。
 
 ## 截图


### PR DESCRIPTION
## Summary
- preregister File Provider domains as soon as a connection is saved
- keep domains registered on Unmount and only remove them when the saved connection is deleted
- separate registered vs connected domain state in mount sync, auto-mount, and startup reconcile flows

## Testing
- make test
- cd Packages/MFuseCore && swift test
- make build

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 保存连接时预先注册 File Provider 域，使应用在系统设置中更早可见。
  * 新增保存后注册同步接口，用于协调已保存连接的注册状态并在失败时显示警告。

* **改进**
  * 协调同步流程增强：统一收集并聚合各类错误、尊重已断开状态，减少状态不一致并改善恢复。
  * 调整挂载/断开语义：断开仅结束会话但保留域，新增断开/重连优化以改善自动重连体验。

* **文档与本地化**
  * 更新文档说明并将本地化文案中 “remove stale domains” 替换为 “reconcile”。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->